### PR TITLE
Lower Go toolchain requirement to 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/joshuafuller/beacon
 
-go 1.24.0
+go 1.21
 
 require (
 	golang.org/x/net v0.46.0


### PR DESCRIPTION
## Summary
- lower the module's Go version directive to 1.21 to match the documented compatibility requirements

## Testing
- not run (tests hang indefinitely when invoking `go test ./...`)


------
https://chatgpt.com/codex/tasks/task_e_690a2999e660832cbab58e82db4492e1