### PR TITLE
Add Go 1.24 and 1.25 to CI build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
       matrix:
         # TODO: Re-enable macOS builds after investigating test failures (see issue #19)
         os: [ubuntu-latest, windows-latest]
-        go-version: ['1.21', '1.22', '1.23']
+        go-version: ['1.21', '1.22', '1.23', '1.24', '1.25']
 
     steps:
     - name: Checkout code

--- a/docs/CI_PIPELINE.md
+++ b/docs/CI_PIPELINE.md
@@ -54,9 +54,9 @@ The Beacon CI pipeline is designed to provide fast feedback while ensuring compr
 **Timeout**: 10 minutes per combination
 
 **Test Matrix**:
-- **Operating Systems**: Ubuntu, macOS, Windows
-- **Go Versions**: 1.21, 1.22, 1.23
-- **Total**: 9 combinations (3 OS × 3 versions)
+- **Operating Systems**: Ubuntu, Windows (macOS currently disabled - see issue #19)
+- **Go Versions**: 1.21, 1.22, 1.23, 1.24, 1.25
+- **Total**: 10 combinations (2 OS × 5 versions)
 
 **What it does**:
 - ✅ Build verification (`go build ./...`)


### PR DESCRIPTION
- Add Go 1.24 and 1.25 to CI build matrix for future-proofing
- Update CI_PIPELINE.md to reflect new Go versions (1.21-1.25)
- Fix OS count documentation (2 OS currently, not 3)
- Note macOS temporarily disabled (issue #19)

Closes #21

Rationale:
- Testing against newer Go versions catches compatibility issues early
- Community adoption of new Go versions is typically rapid
- Minimal CI runtime cost (~2-3 minutes per version)
- Follows best practices for library compatibility testing