### PR TITLE
fix(ci): Pin staticcheck to v0.5.1 for Go 1.21 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 env:
   GO_VERSION: '1.21'
   GOLANGCI_LINT_VERSION: 'v2.5.0'
-  STATICCHECK_VERSION: 'latest'
+  STATICCHECK_VERSION: 'v0.5.1'  # Last version compatible with Go 1.21
 
 jobs:
   # Fast feedback loop - runs on every commit


### PR DESCRIPTION
## Summary

Fix CI failures by pinning staticcheck to v0.5.1, the last version compatible with Go 1.21.

## Problem

PR #13 (and potentially other PRs) are failing Fast CI with this error:
```
go: honnef.co/go/tools@v0.6.1 requires go >= 1.23; switching to go1.24.9
go: no such tool "compile"
```

**Root Cause**: 
- Our Fast CI job uses Go 1.21 (`.github/workflows/ci.yml` line 14)
- We pin staticcheck to `latest`
- The latest staticcheck (v0.6.1+) now requires Go 1.23+
- When Go tries to auto-switch to the required version (Go 1.24.9), it fails because Go 1.24 doesn't exist yet

## Solution

Pin `STATICCHECK_VERSION` to `v0.5.1`, which is the last staticcheck version that supports Go 1.21.

## Changes

- `.github/workflows/ci.yml`: Change `STATICCHECK_VERSION: 'latest'` → `STATICCHECK_VERSION: 'v0.5.1'`
- Added comment explaining the version constraint

## Impact

- ✅ Fixes Fast CI failures in PR #13 and other dependency update PRs
- ✅ Maintains Go 1.21 compatibility
- ✅ No functional changes to linting rules
- ✅ When we upgrade to Go 1.23+, we can update to latest staticcheck

## Alternative Considered

**Option**: Upgrade Fast CI to Go 1.23

**Rejected because**: 
- Breaking change - requires updating minimum Go version across the project
- Should be a separate, deliberate decision (not a CI fix)
- Go 1.21 is still widely used and we want to support it

## Testing

After merge, this will fix CI in:
- PR #13 (Dependabot: golang.org/x/net update)
- Any other PRs experiencing staticcheck installation failures

## References

- Staticcheck compatibility: https://staticcheck.dev/docs/getting-started/
- Staticcheck v0.5.1 release: https://github.com/dominikh/go-tools/releases/tag/v0.5.1
- PR #13: https://github.com/joshuafuller/beacon/pull/13