### PR TITLE
fix(ci): Upgrade Fast CI to Go 1.23 for staticcheck compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: '1.21'
+  GO_VERSION: '1.23'  # Use recent stable version for fast feedback; build matrix tests 1.21-1.25
   GOLANGCI_LINT_VERSION: 'v2.5.0'
   STATICCHECK_VERSION: 'latest'
 


### PR DESCRIPTION
## Summary

Fix CI failures by upgrading GO_VERSION from 1.21 to 1.23, allowing staticcheck@latest to work properly.

## Problem

PR #13 (and other PRs) fail Fast CI with:
```
go: honnef.co/go/tools@v0.6.1 requires go >= 1.23; switching to go1.24.9
go: no such tool "compile"
```

**Root Cause**:
- Fast CI uses Go 1.21
- staticcheck@latest (v0.6.1+) requires Go 1.23+
- Mismatch causes installation failure

## Solution

Upgrade `GO_VERSION` from `1.21` to `1.23` for Fast CI and Full CI jobs.

**Why this is the right fix**:
- ✅ Keeps `STATICCHECK_VERSION: 'latest'` (best practice - auto-updates)
- ✅ Build matrix still tests Go 1.21-1.25 (minimum version covered)
- ✅ Fast CI should use recent stable tooling for quick feedback
- ✅ No change to go.mod (minimum version still 1.21)

## Changes

Single line change in `.github/workflows/ci.yml`:
```diff
- GO_VERSION: '1.21'
+ GO_VERSION: '1.23'  # Use recent stable version for fast feedback; build matrix tests 1.21-1.25
```

## Impact

- ✅ Fixes PR #13 CI failures immediately
- ✅ Maintains Go 1.21 compatibility (build-matrix tests it)
- ✅ Uses modern linter versions automatically
- ✅ Fast CI runs with stable, recent Go version

## Verification Strategy

Our CI has two levels:
1. **Fast CI** (this change): Quick feedback with Go 1.23 + latest tools
2. **Build Matrix**: Comprehensive testing across Go 1.21-1.25

This ensures we get fast feedback while still verifying compatibility with our minimum supported version.

## Alternative Considered

**Option**: Pin staticcheck to v0.5.1 (Go 1.21 compatible)

**Rejected because**:
- Misses latest staticcheck features and bug fixes
- `latest` is best practice for linter tools
- Fast CI doesn't need to test minimum Go version (build-matrix does that)

## References

- PR #13: https://github.com/joshuafuller/beacon/pull/13
- Staticcheck v0.6.1 requirements: https://staticcheck.dev/docs/getting-started/

Closes #13 (will fix after this merges and PR rebases)