### PR TITLE
v1.3.0: responder answers queries on the wire + querier fixes, refactor, test hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to the Beacon mDNS library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-06-20
+
+First release in which the responder actually answers queries on the wire. v1.2.2
+shipped a stubbed responder (`buildResponsePacket` returned an empty packet) and
+never transmitted announcements, so a node was briefly announced but never
+answered queries. **No breaking changes to the public API.**
+
+### Fixed
+- **Responder answers queries on the wire.** Responses are fully serialized
+  (PTR/SRV/TXT/A) and announcements are sent via the transport. (Fixes the
+  v1.2.2 stub that made nodes undiscoverable via active queries.)
+- **Querier `WithTimeout` is now honored for deadline-less contexts.** Previously
+  `Query(context.Background(), …)` could block forever because the configured
+  default timeout was never applied.
+- **`DiscoverServices` now resolves SRV hostname/port.** A type mismatch made
+  `ResourceRecord.AsSRV()` always return `nil`, so instance host/port were never
+  populated for any responder.
+
+### Added
+- **Single-round-trip discovery.** `Response.Additionals` exposes the Additional
+  section and `DiscoverServices` consumes bundled SRV/TXT/A records to skip
+  follow-up queries (RFC 6763 §12). Falls back to explicit queries when a
+  responder omits them.
+- **Actionable service-type validation errors** that name the offending character
+  and cite RFC 6763 §7 (e.g. embedded underscores).
+
+### Changed
+- Internal architecture: the `responder` package is split into cohesive files;
+  the rate limiter and record TTL/multicast trackers use an injectable clock for
+  deterministic tests; extensive fuzz and mutation-test hardening was added. No
+  public API impact.
+
+### Known limitations
+- SRV/PTR targets that use DNS name compression (common in Avahi/Bonjour
+  responses) are not yet resolved from RDATA, so cross-responder SRV resolution
+  is limited. Beacon-to-beacon discovery is unaffected (Beacon does not compress).
+  Tracked as a follow-up (`ParseRDATA` needs full-message context).
+
 ## [Unreleased]
 
 ### M1-Refactoring (2025-11-01) - Internal Architecture Overhaul

--- a/examples/intermediate/logging-integration/main.go
+++ b/examples/intermediate/logging-integration/main.go
@@ -18,14 +18,14 @@ func main() {
 	// Configure structured logging
 	logLevel := getLogLevel(os.Getenv("LOG_LEVEL"))
 	logFormat := os.Getenv("LOG_FORMAT")
-	
+
 	var handler slog.Handler
 	if logFormat == "json" {
 		handler = slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: logLevel})
 	} else {
 		handler = slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: logLevel})
 	}
-	
+
 	logger := slog.New(handler)
 	slog.SetDefault(logger)
 
@@ -52,32 +52,32 @@ func main() {
 	}
 
 	logger.Debug("Registering service", "instance", svc.InstanceName, "type", svc.ServiceType, "port", svc.Port)
-	
+
 	if err := resp.Register(svc); err != nil {
 		logger.Error("Service registration failed", "error", err, "service", svc.InstanceName)
 		log.Fatal(err)
 	}
 
-	logger.Info("Service registered successfully", 
-		"service", svc.InstanceName, 
+	logger.Info("Service registered successfully",
+		"service", svc.InstanceName,
 		"type", svc.ServiceType,
 		"port", svc.Port,
 		"txt_records", svc.TXTRecords)
 
 	fmt.Println("Press Ctrl+C to stop")
-	
+
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 	<-sigChan
 
 	logger.Info("Shutdown signal received")
-	
+
 	// Simulate graceful shutdown logging
 	shutdownStart := time.Now()
 	logger.Debug("Beginning graceful shutdown")
-	
+
 	time.Sleep(100 * time.Millisecond) // Simulate cleanup
-	
+
 	logger.Info("Shutdown complete", "duration_ms", time.Since(shutdownStart).Milliseconds())
 }
 

--- a/examples/intermediate/multi-interface-bridge/bridge.go
+++ b/examples/intermediate/multi-interface-bridge/bridge.go
@@ -51,7 +51,7 @@ func (b *Bridge) Start(ctx context.Context) error {
 	// - Start goroutines for each interface
 	// - Implement query forwarding logic
 	// - Handle context cancellation
-	
+
 	fmt.Println("NOTE: This is an educational example.")
 	fmt.Println("Production bridging requires platform-specific interface binding.")
 	fmt.Println("See F-10 Network Interface Management spec for implementation details.\n")

--- a/examples/intermediate/service-updates/main.go
+++ b/examples/intermediate/service-updates/main.go
@@ -17,11 +17,11 @@ import (
 )
 
 const (
-	serviceName   = "Load Monitor"
-	serviceType   = "_http._tcp.local"
-	port          = 8080
+	serviceName    = "Load Monitor"
+	serviceType    = "_http._tcp.local"
+	port           = 8080
 	updateInterval = 5 * time.Second
-	maxUpdates    = 6 // Run for 30 seconds total
+	maxUpdates     = 6 // Run for 30 seconds total
 )
 
 func main() {

--- a/examples/intermediate/web-server/main.go
+++ b/examples/intermediate/web-server/main.go
@@ -89,10 +89,10 @@ func main() {
 // handleRequest serves HTTP requests with a simple message.
 func handleRequest(w http.ResponseWriter, r *http.Request) {
 	log.Printf("HTTP %s %s from %s", r.Method, r.URL.Path, r.RemoteAddr)
-	
+
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	
+
 	fmt.Fprintln(w, "Hello from mDNS-discoverable server!")
 	fmt.Fprintf(w, "Discovered via: %s.%s\n", "Web Demo", "_http._tcp.local")
 	fmt.Fprintf(w, "Time: %s\n", time.Now().Format(time.RFC3339))

--- a/internal/protocol/validator_test.go
+++ b/internal/protocol/validator_test.go
@@ -191,6 +191,53 @@ func TestValidateName_RFC1035_MaxNameLength(t *testing.T) {
 	}
 }
 
+// TestIsValidDNSChar_Boundaries exhaustively pins the character-class boundaries
+// of isValidDNSChar per RFC 1035 §3.1 plus the mDNS underscore extension
+// (RFC 6763): valid set is [a-zA-Z0-9-_].
+//
+// This test exists to lock the EXACT edges of each range. Mutation testing
+// (gremlins) showed that without it, CONDITIONALS_BOUNDARY and
+// CONDITIONALS_NEGATION mutants on the 'a'/'z', 'A'/'Z', '0'/'9' comparisons
+// survive — i.e. the suite could not tell `>=` from `>`. Each "just outside"
+// case below is the neighbour byte immediately adjacent to a range edge, so it
+// fails the moment any boundary or negation is perturbed.
+func TestIsValidDNSChar_Boundaries(t *testing.T) {
+	valid := []rune{
+		'a', 'z', // lower bounds of [a-z]
+		'A', 'Z', // bounds of [A-Z]
+		'0', '9', // bounds of [0-9]
+		'-', '_', // explicit allowed punctuation
+		'm', 'M', '5', // interior sanity
+	}
+	for _, ch := range valid {
+		if !isValidDNSChar(ch) {
+			t.Errorf("isValidDNSChar(%q / 0x%02x) = false, want true (valid per RFC 1035 §3.1 + mDNS)", ch, ch)
+		}
+	}
+
+	// Each rune below is the byte immediately adjacent to a range edge, so it
+	// must be rejected; if a boundary slips by one, one of these flips.
+	invalid := []rune{
+		'`',  // 0x60, immediately before 'a' (0x61)
+		'{',  // 0x7b, immediately after 'z' (0x7a)
+		'@',  // 0x40, immediately before 'A' (0x41)
+		'[',  // 0x5b, immediately after 'Z' (0x5a)
+		'/',  // 0x2f, immediately before '0' (0x30)
+		':',  // 0x3a, immediately after '9' (0x39)
+		',',  // 0x2c, immediately before '-' (0x2d)
+		'.',  // 0x2e, immediately after '-' (label separator, never a char)
+		'^',  // 0x5e, immediately before '_' (0x5f)
+		' ',  // space — common in instance names, never valid in a label
+		'\n', // newline — injection probe
+		'!', '~', 0x00,
+	}
+	for _, ch := range invalid {
+		if isValidDNSChar(ch) {
+			t.Errorf("isValidDNSChar(%q / 0x%02x) = true, want false (outside [a-zA-Z0-9-_])", ch, ch)
+		}
+	}
+}
+
 // TestValidateRecordType_FR002_SupportedTypes validates that ValidateRecordType
 // accepts only A, PTR, SRV, and TXT record types per FR-002.
 //

--- a/internal/records/record_set.go
+++ b/internal/records/record_set.go
@@ -118,9 +118,9 @@ func buildSRVRecord(service *ServiceInfo) *message.ResourceRecord {
 	//   Weight (2 bytes, big-endian) = 0
 	//   Port (2 bytes, big-endian)
 	//   Target (hostname as DNS name)
-	data := make([]byte, 6)                  // Priority + Weight + Port
-	binary.BigEndian.PutUint16(data[0:2], 0) // Priority = 0
-	binary.BigEndian.PutUint16(data[2:4], 0) // Weight = 0
+	data := make([]byte, 6)                             // Priority + Weight + Port
+	binary.BigEndian.PutUint16(data[0:2], 0)            // Priority = 0
+	binary.BigEndian.PutUint16(data[2:4], 0)            // Weight = 0
 	binary.BigEndian.PutUint16(data[4:6], service.Port) // Port
 
 	// Append encoded hostname
@@ -251,6 +251,11 @@ type RecordSet struct {
 	// Key: buildRecordKey(rr) + ":" + interfaceID
 	// Value: timestamp of last multicast (Unix nanoseconds for 250ms probe defense precision)
 	lastMulticast map[string]int64
+
+	// now returns the current time; defaults to time.Now. Exists only so tests
+	// can supply a deterministic clock and exercise the RFC 6762 §6.2 rate-limit
+	// boundaries (1s / 250ms) exactly.
+	now func() time.Time
 }
 
 // NewRecordSet creates a new RecordSet for rate limiting tracking.
@@ -259,7 +264,17 @@ type RecordSet struct {
 func NewRecordSet() *RecordSet {
 	return &RecordSet{
 		lastMulticast: make(map[string]int64),
+		now:           time.Now,
 	}
+}
+
+// clockNow returns the current time, tolerating a zero-value RecordSet (e.g. a
+// struct literal) by falling back to time.Now.
+func (rs *RecordSet) clockNow() time.Time {
+	if rs.now != nil {
+		return rs.now()
+	}
+	return time.Now()
 }
 
 // CanMulticast checks if a record can be multicast on the given interface per RFC 6762 §6.2.
@@ -282,7 +297,7 @@ func (rs *RecordSet) CanMulticast(rr *ResourceRecord, interfaceID string) bool {
 	}
 
 	// RFC 6762 §6.2: Minimum 1 second (1e9 nanoseconds) between multicasts
-	elapsedNano := time.Now().UnixNano() - lastTimeNano
+	elapsedNano := rs.clockNow().UnixNano() - lastTimeNano
 	return elapsedNano >= 1e9 // 1 second = 1,000,000,000 nanoseconds
 }
 
@@ -308,7 +323,7 @@ func (rs *RecordSet) CanMulticastProbeDefense(rr *ResourceRecord, interfaceID st
 	}
 
 	// RFC 6762 §6.2: Probe defense minimum 250ms = 250,000,000 nanoseconds
-	elapsedNano := time.Now().UnixNano() - lastTimeNano
+	elapsedNano := rs.clockNow().UnixNano() - lastTimeNano
 	return elapsedNano >= 250e6 // 250ms in nanoseconds
 }
 
@@ -319,7 +334,7 @@ func (rs *RecordSet) CanMulticastProbeDefense(rr *ResourceRecord, interfaceID st
 // T074: Implement RecordMulticast()
 func (rs *RecordSet) RecordMulticast(rr *ResourceRecord, interfaceID string) {
 	key := rs.buildRecordKey(rr) + ":" + interfaceID
-	rs.lastMulticast[key] = time.Now().UnixNano()
+	rs.lastMulticast[key] = rs.clockNow().UnixNano()
 }
 
 // GetLastMulticast returns the last multicast time for a record on an interface.

--- a/internal/records/record_set_test.go
+++ b/internal/records/record_set_test.go
@@ -2,9 +2,84 @@ package records
 
 import (
 	"testing"
+	"time"
 
 	"github.com/joshuafuller/beacon/internal/protocol"
 )
+
+// recordsClock is a deterministic clock for exercising the RFC 6762 §6.2
+// rate-limit boundaries (1s multicast, 250ms probe defense) and TTL expiry
+// exactly — wall clock cannot reliably land on an edge like "elapsed == 1s".
+type recordsClock struct{ t time.Time }
+
+func (c *recordsClock) Now() time.Time          { return c.t }
+func (c *recordsClock) advance(d time.Duration) { c.t = c.t.Add(d) }
+
+func newRecordsClock() *recordsClock {
+	return &recordsClock{t: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+}
+
+func multicastTestRecord() *ResourceRecord {
+	return &ResourceRecord{
+		Name:  "myservice._http._tcp.local",
+		Type:  protocol.RecordTypePTR,
+		Class: protocol.ClassIN,
+		TTL:   4500,
+		Data:  []byte{0x08, 'M', 'y', 'P', 'r', 'i', 'n', 't', 'e', 'r'},
+	}
+}
+
+// TestResourceRecord_CanMulticast_Boundary pins the 1-second edge in
+// CanMulticast (record_set.go: `elapsedNano >= 1e9`). At exactly one second the
+// record may be multicast again; one nanosecond before, it may not. The fake
+// clock lands on the edge precisely, killing the boundary mutant.
+func TestResourceRecord_CanMulticast_Boundary(t *testing.T) {
+	const iface = "eth0"
+
+	// Exactly 1s elapsed -> allowed.
+	clk := newRecordsClock()
+	rs := NewRecordSet()
+	rs.now = clk.Now
+	rs.RecordMulticast(multicastTestRecord(), iface)
+	clk.advance(time.Second)
+	if !rs.CanMulticast(multicastTestRecord(), iface) {
+		t.Fatalf("CanMulticast = false at exactly 1s elapsed; RFC 6762 §6.2 boundary is >= 1s, must be allowed")
+	}
+
+	// One nanosecond before 1s -> denied.
+	clk2 := newRecordsClock()
+	rs2 := NewRecordSet()
+	rs2.now = clk2.Now
+	rs2.RecordMulticast(multicastTestRecord(), iface)
+	clk2.advance(time.Second - time.Nanosecond)
+	if rs2.CanMulticast(multicastTestRecord(), iface) {
+		t.Fatalf("CanMulticast = true at 1s-1ns elapsed; must be denied (< 1s)")
+	}
+}
+
+// TestResourceRecord_CanMulticastProbeDefense_Boundary pins the 250ms edge in
+// CanMulticastProbeDefense (record_set.go: `elapsedNano >= 250e6`).
+func TestResourceRecord_CanMulticastProbeDefense_Boundary(t *testing.T) {
+	const iface = "eth0"
+
+	clk := newRecordsClock()
+	rs := NewRecordSet()
+	rs.now = clk.Now
+	rs.RecordMulticast(multicastTestRecord(), iface)
+	clk.advance(250 * time.Millisecond)
+	if !rs.CanMulticastProbeDefense(multicastTestRecord(), iface) {
+		t.Fatalf("CanMulticastProbeDefense = false at exactly 250ms; RFC 6762 §6.2 boundary is >= 250ms, must be allowed")
+	}
+
+	clk2 := newRecordsClock()
+	rs2 := NewRecordSet()
+	rs2.now = clk2.Now
+	rs2.RecordMulticast(multicastTestRecord(), iface)
+	clk2.advance(250*time.Millisecond - time.Nanosecond)
+	if rs2.CanMulticastProbeDefense(multicastTestRecord(), iface) {
+		t.Fatalf("CanMulticastProbeDefense = true at 250ms-1ns; must be denied (< 250ms)")
+	}
+}
 
 // TestBuildTXTRecord_EmptyMandatory_RED tests RFC 6763 §6 mandatory TXT record.
 //

--- a/internal/records/ttl.go
+++ b/internal/records/ttl.go
@@ -16,6 +16,19 @@ type RecordTTL struct {
 	RecordType protocol.RecordType
 	TTL        uint32    // Initial TTL in seconds
 	CreatedAt  time.Time // Creation timestamp for TTL calculation
+
+	// now returns the current time; defaults to time.Now. Exists only so tests
+	// can supply a deterministic clock and exercise the expiry boundary exactly.
+	now func() time.Time
+}
+
+// clockNow returns the current time, tolerating a zero-value/literal RecordTTL
+// by falling back to time.Now.
+func (r *RecordTTL) clockNow() time.Time {
+	if r.now != nil {
+		return r.now()
+	}
+	return time.Now()
 }
 
 // NewRecordTTL creates a new record with TTL tracking.
@@ -33,6 +46,7 @@ func NewRecordTTL(rt protocol.RecordType, ttl uint32) *RecordTTL {
 		RecordType: rt,
 		TTL:        ttl,
 		CreatedAt:  time.Now(),
+		now:        time.Now,
 	}
 }
 
@@ -45,7 +59,7 @@ func NewRecordTTL(rt protocol.RecordType, ttl uint32) *RecordTTL {
 //
 // T017: Implement TTL calculation
 func (r *RecordTTL) GetRemainingTTL() uint32 {
-	elapsed := uint32(time.Since(r.CreatedAt).Seconds())
+	elapsed := uint32(r.clockNow().Sub(r.CreatedAt).Seconds())
 
 	// If elapsed time >= TTL, record has expired
 	if elapsed >= r.TTL {
@@ -62,7 +76,7 @@ func (r *RecordTTL) GetRemainingTTL() uint32 {
 //
 // T017: Implement expiration check
 func (r *RecordTTL) IsExpired() bool {
-	elapsed := time.Since(r.CreatedAt)
+	elapsed := r.clockNow().Sub(r.CreatedAt)
 	return elapsed >= time.Duration(r.TTL)*time.Second
 }
 

--- a/internal/records/ttl_test.go
+++ b/internal/records/ttl_test.go
@@ -7,6 +7,30 @@ import (
 	"github.com/joshuafuller/beacon/internal/protocol"
 )
 
+// TestTTL_IsExpired_Boundary pins the expiry edge in IsExpired
+// (ttl.go: `elapsed >= time.Duration(r.TTL)*time.Second`). At exactly TTL
+// seconds the record IS expired; one nanosecond before, it is NOT. A deterministic
+// clock lands on the edge precisely, killing the boundary mutant that wall-clock
+// tests cannot. (GetRemainingTTL's own `>=` is an equivalent mutant — it returns
+// 0 either way at the edge — so only IsExpired is pinned here.)
+func TestTTL_IsExpired_Boundary(t *testing.T) {
+	const ttl = 100
+	rt := NewRecordTTL(protocol.RecordTypeA, ttl)
+	base := rt.CreatedAt
+
+	// Exactly TTL seconds elapsed -> expired.
+	rt.now = func() time.Time { return base.Add(ttl * time.Second) }
+	if !rt.IsExpired() {
+		t.Fatalf("IsExpired = false at exactly TTL (%ds) elapsed; boundary is >=, must be expired", ttl)
+	}
+
+	// One nanosecond before TTL -> not expired.
+	rt.now = func() time.Time { return base.Add(ttl*time.Second - time.Nanosecond) }
+	if rt.IsExpired() {
+		t.Fatalf("IsExpired = true at TTL-1ns elapsed; must NOT be expired yet")
+	}
+}
+
 // TestTTL_GetRemainingTTL_RED tests remaining TTL calculation.
 //
 // TDD Phase: RED - These tests will FAIL until we implement TTL management

--- a/internal/security/rate_limiter.go
+++ b/internal/security/rate_limiter.go
@@ -27,6 +27,11 @@ type RateLimiter struct {
 	sources       map[string]*RateLimitEntry // Source IP → RateLimitEntry
 	mu            sync.RWMutex               // Protects sources map
 	evictionCount uint64                     // Number of LRU evictions (for metrics)
+
+	// now returns the current time. It defaults to time.Now and exists only so
+	// that tests can supply a deterministic clock to exercise the time-based
+	// boundaries (window expiry, cooldown, LRU ordering, cleanup) exactly.
+	now func() time.Time
 }
 
 // NewRateLimiter creates a new rate limiter with the given configuration.
@@ -37,6 +42,7 @@ func NewRateLimiter(threshold int, cooldown time.Duration, maxEntries int) *Rate
 		cooldown:   cooldown,
 		maxEntries: maxEntries,
 		sources:    make(map[string]*RateLimitEntry),
+		now:        time.Now,
 	}
 }
 
@@ -57,11 +63,12 @@ func (rl *RateLimiter) Allow(sourceIP string) bool {
 		// Check again after acquiring write lock (double-check pattern)
 		entry, exists = rl.sources[sourceIP]
 		if !exists {
+			tNow := rl.now()
 			rl.sources[sourceIP] = &RateLimitEntry{
 				sourceIP:    sourceIP,
 				queryCount:  1,
-				windowStart: time.Now(),
-				lastSeen:    time.Now(),
+				windowStart: tNow,
+				lastSeen:    tNow,
 			}
 			// Check if map exceeded maxEntries
 			if len(rl.sources) > rl.maxEntries {
@@ -76,7 +83,7 @@ func (rl *RateLimiter) Allow(sourceIP string) bool {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 
-	now := time.Now()
+	now := rl.now()
 
 	// Check cooldown (after acquiring lock)
 	if !entry.cooldownExpiry.IsZero() && now.Before(entry.cooldownExpiry) {
@@ -158,10 +165,9 @@ func (rl *RateLimiter) evict() {
 		evicted++
 	}
 
-	// G115: bounds checked - evicted is always non-negative and less than evictCount (which is at most maxEntries/10)
-	if evicted >= 0 { //nolint:gosec // G115: bounds checked
-		rl.evictionCount += uint64(evicted)
-	}
+	// evicted is always >= 0 (it only increments from 0), so no guard is needed.
+	// G115: conversion is safe — evicted is non-negative and at most maxEntries/10.
+	rl.evictionCount += uint64(evicted) //nolint:gosec // G115: bounds checked
 }
 
 // Cleanup removes stale entries from the rate limiter map.
@@ -171,7 +177,7 @@ func (rl *RateLimiter) Cleanup() {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 
-	now := time.Now()
+	now := rl.now()
 	toDelete := make([]string, 0)
 
 	// Find stale entries (not seen recently)

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -467,3 +467,193 @@ func TestSourceFilter_IsValid_RejectsDifferentSubnet_Agent4(t *testing.T) {
 		t.Errorf("IsValid(%s) = false, want true (IP is in same subnet 10.0.1.0/24)", sameSubnetIP)
 	}
 }
+
+// manualClock is a deterministic clock for exercising the rate limiter's
+// time-based boundaries (window expiry, LRU ordering, cleanup) exactly — wall
+// clock cannot hit an edge like "elapsed == 1s" reliably.
+type manualClock struct{ t time.Time }
+
+func (c *manualClock) Now() time.Time          { return c.t }
+func (c *manualClock) advance(d time.Duration) { c.t = c.t.Add(d) }
+
+func newManualClock() *manualClock {
+	return &manualClock{t: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+}
+
+// queryCountOf returns the current sliding-window count for a source (test-only
+// white-box inspection).
+func queryCountOf(rl *RateLimiter, ip string) (int, bool) {
+	rl.mu.RLock() // nosemgrep: beacon-mutex-defer-unlock
+	defer rl.mu.RUnlock()
+	e, ok := rl.sources[ip]
+	if !ok {
+		return 0, false
+	}
+	return e.queryCount, true
+}
+
+func hasSource(rl *RateLimiter, ip string) bool {
+	rl.mu.RLock() // nosemgrep: beacon-mutex-defer-unlock
+	defer rl.mu.RUnlock()
+	_, ok := rl.sources[ip]
+	return ok
+}
+
+// TestRateLimiter_WindowExpiry_Boundary pins the sliding-window reset edge
+// (rate_limiter.go: `now.Sub(entry.windowStart) > 1*time.Second`). At exactly
+// 1 second the window must NOT reset; strictly past 1 second it must. A fake
+// clock lets us land on the edge precisely, killing the boundary mutant that
+// wall-clock tests cannot.
+func TestRateLimiter_WindowExpiry_Boundary(t *testing.T) {
+	clk := newManualClock()
+	rl := NewRateLimiter(100, time.Hour, 10000) // high threshold so we never cool down
+	rl.now = clk.Now
+	const src = "203.0.113.7"
+
+	rl.Allow(src)            // create: count=1, windowStart=T0
+	clk.advance(time.Second) // now == windowStart + exactly 1s
+	rl.Allow(src)            // 1s is NOT > 1s → must increment, not reset
+	if c, _ := queryCountOf(rl, src); c != 2 {
+		t.Fatalf("queryCount = %d at exactly windowStart+1s; window must NOT reset (expected 2)", c)
+	}
+
+	clk.advance(time.Nanosecond) // now strictly past 1s relative to windowStart
+	rl.Allow(src)                // now > 1s → must reset window to count=1
+	if c, _ := queryCountOf(rl, src); c != 1 {
+		t.Fatalf("queryCount = %d strictly past windowStart+1s; window must reset (expected 1)", c)
+	}
+}
+
+// TestRateLimiter_Cleanup_Boundary pins the staleness edge in Cleanup()
+// (`now.Sub(entry.lastSeen) > 1*time.Minute`). At exactly one minute the entry
+// must be kept; strictly past one minute it must be removed.
+func TestRateLimiter_Cleanup_Boundary(t *testing.T) {
+	clk := newManualClock()
+	rl := NewRateLimiter(100, time.Hour, 10000)
+	rl.now = clk.Now
+	const src = "203.0.113.8"
+
+	rl.Allow(src) // lastSeen = T0
+	clk.advance(time.Minute)
+	rl.Cleanup()
+	if !hasSource(rl, src) {
+		t.Fatalf("entry removed at exactly lastSeen+1m; it must be kept (boundary is strictly > 1m)")
+	}
+
+	clk.advance(time.Nanosecond)
+	rl.Cleanup()
+	if hasSource(rl, src) {
+		t.Fatalf("entry kept strictly past lastSeen+1m; it must be removed")
+	}
+}
+
+// TestRateLimiter_Evict_RemovesOldest pins the LRU selection in evict(): it must
+// remove the entries with the OLDEST lastSeen, not the newest. A distinct,
+// monotonically advancing timestamp per source makes the ordering unambiguous,
+// killing the `lastSeen.Before(...)` comparison mutant and the partial-sort /
+// delete-loop boundary mutants.
+func TestRateLimiter_Evict_RemovesOldest(t *testing.T) {
+	clk := newManualClock()
+	const maxEntries = 20 // evictCount = maxEntries/10 = 2
+	rl := NewRateLimiter(1000, time.Hour, maxEntries)
+	rl.now = clk.Now
+
+	// Fill exactly maxEntries sources, each 1s newer than the last.
+	for i := 0; i < maxEntries; i++ {
+		rl.Allow(fmt.Sprintf("198.51.100.%d", i))
+		clk.advance(time.Second)
+	}
+	// One more source trips eviction of the 2 oldest (ip 0 and ip 1).
+	rl.Allow("198.51.100.200")
+
+	if rl.evictionCount != 2 {
+		t.Fatalf("evictionCount = %d; expected 2 (maxEntries/10)", rl.evictionCount)
+	}
+	if hasSource(rl, "198.51.100.0") {
+		t.Errorf("oldest source .0 survived eviction; evict() must remove oldest-by-lastSeen")
+	}
+	if hasSource(rl, "198.51.100.1") {
+		t.Errorf("second-oldest source .1 survived eviction; evict() must remove oldest-by-lastSeen")
+	}
+	if !hasSource(rl, "198.51.100.2") {
+		t.Errorf("source .2 was evicted; only the 2 OLDEST should be removed")
+	}
+	if !hasSource(rl, "198.51.100.200") {
+		t.Errorf("newest source was evicted; evict() must remove oldest, not newest")
+	}
+}
+
+// TestRateLimiter_Allow_ThresholdBoundary pins the EXACT threshold edge in
+// Allow() (rate_limiter.go:110, `entry.queryCount > rl.threshold`).
+//
+// Mutation testing showed the existing exceeds-threshold test asserts only
+// "allowedCount <= 100", which lets a `>`→`>=` (or `>`→`>=` boundary) mutant
+// survive. Here threshold=5 and the queries are issued in a tight loop (well
+// within the 1s window, so the window never resets): exactly the first
+// `threshold` queries must be allowed and the very next one denied.
+func TestRateLimiter_Allow_ThresholdBoundary(t *testing.T) {
+	const threshold = 5
+	rl := NewRateLimiter(threshold, 60*time.Second, 10000)
+	const src = "192.168.1.200"
+
+	for i := 1; i <= threshold; i++ {
+		if !rl.Allow(src) {
+			t.Fatalf("query %d/%d denied; the first %d queries must be allowed (queryCount %d is not > threshold %d)", i, threshold, threshold, i, threshold)
+		}
+	}
+	// The (threshold+1)th query is the first to exceed the limit.
+	if rl.Allow(src) {
+		t.Fatalf("query %d was allowed; it exceeds threshold %d (queryCount %d > %d) and must be denied", threshold+1, threshold, threshold+1, threshold)
+	}
+}
+
+// TestRateLimiter_Eviction_Boundary pins the maxEntries eviction edge
+// (rate_limiter.go:67, `len(rl.sources) > rl.maxEntries`) and the eviction
+// arithmetic (`evictCount := rl.maxEntries / 10`, rate_limiter.go:124).
+//
+// Filling exactly maxEntries distinct sources must NOT evict; one more must
+// evict exactly maxEntries/10 entries. The exact post-eviction size kills both
+// the boundary mutant (>= would evict early) and the arithmetic mutants
+// (*,+,- all yield a different evict count and thus a different final size).
+func TestRateLimiter_Eviction_Boundary(t *testing.T) {
+	const maxEntries = 100
+	rl := NewRateLimiter(1000, 60*time.Second, maxEntries) // high threshold: never rate-limit
+
+	for i := 0; i < maxEntries; i++ {
+		rl.Allow(fmt.Sprintf("10.0.%d.%d", i/256, i%256))
+	}
+	if got := rl.evictionCount; got != 0 {
+		t.Fatalf("evictionCount = %d after exactly maxEntries=%d sources; expected 0 (len == maxEntries is not > maxEntries)", got, maxEntries)
+	}
+	if got := len(rl.sources); got != maxEntries {
+		t.Fatalf("sources size = %d after filling to maxEntries; expected %d", got, maxEntries)
+	}
+
+	// One more distinct source pushes len to maxEntries+1 (> maxEntries) -> evict 10%.
+	rl.Allow("10.99.99.99")
+	const wantEvicted = maxEntries / 10 // 10
+	if got := rl.evictionCount; got != wantEvicted {
+		t.Fatalf("evictionCount = %d after exceeding maxEntries; expected exactly maxEntries/10 = %d", got, wantEvicted)
+	}
+	if got, want := len(rl.sources), maxEntries+1-wantEvicted; got != want {
+		t.Fatalf("sources size = %d after eviction; expected %d (%d added - %d evicted)", got, want, maxEntries+1, wantEvicted)
+	}
+}
+
+// TestRateLimiter_Eviction_MinimumOne pins the "evict at least one" guard
+// (rate_limiter.go:125, `if evictCount == 0 { evictCount = 1 }`) for small
+// maxEntries where maxEntries/10 == 0.
+func TestRateLimiter_Eviction_MinimumOne(t *testing.T) {
+	const maxEntries = 5 // maxEntries/10 == 0 -> must clamp to 1
+	rl := NewRateLimiter(1000, 60*time.Second, maxEntries)
+
+	for i := 0; i <= maxEntries; i++ { // maxEntries+1 distinct sources
+		rl.Allow(fmt.Sprintf("172.16.0.%d", i))
+	}
+	if got := rl.evictionCount; got != 1 {
+		t.Fatalf("evictionCount = %d for maxEntries=%d; expected exactly 1 (maxEntries/10 rounds to 0, clamped to 1)", got, maxEntries)
+	}
+	if got := len(rl.sources); got != maxEntries {
+		t.Fatalf("sources size = %d after eviction; expected %d", got, maxEntries)
+	}
+}

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -143,13 +143,22 @@ func TestRateLimiter_Cooldown(t *testing.T) {
 // TestRateLimiter_BoundedMap verifies LRU eviction at 10,000 entries.
 // Per F-11 REQ-F11-4: Prevent memory exhaustion.
 func TestRateLimiter_BoundedMap(t *testing.T) {
-	// Create RateLimiter with maxEntries=100 (small for testing)
+	// Create RateLimiter with maxEntries=100 (small for testing).
 	rl := NewRateLimiter(100, 60*time.Second, 100)
 
-	// Send queries from 150 unique source IPs
+	// Use a deterministic clock that advances per query so each source has a
+	// strictly increasing lastSeen. Without this the test is flaky on platforms
+	// with coarse timer resolution (e.g. Windows ~15ms): all entries get the
+	// same time.Now() value, making LRU eviction order arbitrary so the "newest"
+	// entry can be evicted.
+	clk := newManualClock()
+	rl.now = clk.Now
+
+	// Send queries from 150 unique source IPs.
 	for i := 0; i < 150; i++ {
 		sourceIP := fmt.Sprintf("192.168.1.%d", i)
 		rl.Allow(sourceIP)
+		clk.advance(time.Millisecond)
 	}
 
 	// Verify map size never exceeds 100
@@ -167,7 +176,9 @@ func TestRateLimiter_BoundedMap(t *testing.T) {
 		t.Error("Expected evictionCount > 0 after exceeding maxEntries, but got 0")
 	}
 
-	// Test LRU behavior: Add a new source, verify it's in the map
+	// Test LRU behavior: Add a new source (newest lastSeen), verify it survives
+	// eviction — the eviction it triggers must remove the OLDEST entries, not it.
+	clk.advance(time.Millisecond)
 	newestIP := "10.0.0.1"
 	rl.Allow(newestIP)
 

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -262,6 +262,19 @@ func TestIsPrivate(t *testing.T) {
 		{"192.168 private", "192.168.1.1", true},
 		{"Public IP", "8.8.8.8", false},
 		{"Link-local", "169.254.1.1", false}, // Link-local is NOT private range
+
+		// 172.16.0.0/12 range boundaries (pins ip4[1] >= 16 && ip4[1] <= 31).
+		// Without these, mutation testing showed the `<= 31` / `>= 16` edges survive.
+		{"172.15 just below range", "172.15.255.255", false}, // 15 < 16 → not private
+		{"172.16 lower edge", "172.16.0.0", true},            // exactly 16 → private
+		{"172.31 upper edge", "172.31.255.255", true},        // exactly 31 → private
+		{"172.32 just above range", "172.32.0.0", false},     // 32 > 31 → not private
+		// 192.168.0.0/16 neighbours (pins ip4[1] == 168).
+		{"192.167 not private", "192.167.1.1", false},
+		{"192.169 not private", "192.169.1.1", false},
+		// 10/8 boundary neighbours (pins ip4[0] == 10).
+		{"9.x not private", "9.255.255.255", false},
+		{"11.x not private", "11.0.0.0", false},
 	}
 
 	for _, tt := range tests {
@@ -273,6 +286,46 @@ func TestIsPrivate(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestNewSourceFilter_CachesInterfaceAddrs exercises the real NewSourceFilter
+// constructor (the other SourceFilter tests build the struct literally and so
+// never run it). On an interface whose Addrs() succeeds, the constructor MUST
+// cache the interface's *net.IPNet addresses — not take the empty error-path
+// fallback. Mutation testing flagged the `if err != nil` branch as uncovered;
+// this asserts the success path populates ifaceAddrs.
+func TestNewSourceFilter_CachesInterfaceAddrs(t *testing.T) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		t.Skipf("cannot list interfaces in this environment: %v", err)
+	}
+
+	for _, iface := range ifaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		wantIPNets := 0
+		for _, a := range addrs {
+			if _, ok := a.(*net.IPNet); ok {
+				wantIPNets++
+			}
+		}
+		if wantIPNets == 0 {
+			continue // need an interface with at least one IPNet to be decisive
+		}
+
+		sf, err := NewSourceFilter(iface)
+		if err != nil {
+			t.Fatalf("NewSourceFilter(%s) returned error: %v", iface.Name, err)
+		}
+		if len(sf.ifaceAddrs) != wantIPNets {
+			t.Fatalf("NewSourceFilter(%s) cached %d addrs, want %d (success path must cache, not take the empty fallback)",
+				iface.Name, len(sf.ifaceAddrs), wantIPNets)
+		}
+		return // one decisive interface is enough
+	}
+	t.Skip("no interface with an IPNet address available to exercise the constructor")
 }
 
 // ===== USER STORY 4: SOURCE FILTER TESTS (T067-T070) =====

--- a/internal/state/prober_test.go
+++ b/internal/state/prober_test.go
@@ -505,7 +505,7 @@ func buildTestResponsePacket(name string, ip net.IP) []byte {
 	// DNS Header (12 bytes): QR=1 (response), ANCOUNT=1
 	header := make([]byte, 12)
 	binary.BigEndian.PutUint16(header[2:4], 0x8400) // QR=1, AA=1
-	binary.BigEndian.PutUint16(header[6:8], 1)       // ANCOUNT = 1
+	binary.BigEndian.PutUint16(header[6:8], 1)      // ANCOUNT = 1
 
 	// Answer section: NAME + TYPE(A=1) + CLASS(IN=1) + TTL + RDLENGTH + RDATA
 	answer := make([]byte, 0, len(encodedName)+10+4)

--- a/internal/transport/mock.go
+++ b/internal/transport/mock.go
@@ -17,7 +17,7 @@ type MockTransport struct {
 	sendCalls       []SendCall
 	closed          bool
 	receiveQueue    []mockReceiveResponse // Queued responses for Receive()
-	receiveNotifyCh chan struct{}          // Signals when a new response is queued
+	receiveNotifyCh chan struct{}         // Signals when a new response is queued
 	blockOnReceive  bool                  // When true, Receive blocks until data or ctx cancel
 }
 

--- a/querier/collectresponses_test.go
+++ b/querier/collectresponses_test.go
@@ -300,12 +300,12 @@ func buildValidResponsePacket(name string, rtype protocol.RecordType, rdata []by
 	packet := make([]byte, 0, 512)
 
 	// Header: 12 bytes
-	packet = append(packet, 0x00, 0x00)       // ID
-	packet = append(packet, 0x80, 0x00)       // Flags: QR=1 (response), RCODE=0
-	packet = append(packet, 0x00, 0x00)       // QDCOUNT=0
-	packet = append(packet, 0x00, 0x01)       // ANCOUNT=1
-	packet = append(packet, 0x00, 0x00)       // NSCOUNT=0
-	packet = append(packet, 0x00, 0x00)       // ARCOUNT=0
+	packet = append(packet, 0x00, 0x00) // ID
+	packet = append(packet, 0x80, 0x00) // Flags: QR=1 (response), RCODE=0
+	packet = append(packet, 0x00, 0x00) // QDCOUNT=0
+	packet = append(packet, 0x00, 0x01) // ANCOUNT=1
+	packet = append(packet, 0x00, 0x00) // NSCOUNT=0
+	packet = append(packet, 0x00, 0x00) // ARCOUNT=0
 
 	// Answer section:
 	// NAME (encoded as DNS labels)
@@ -341,12 +341,12 @@ func buildQueryPacket(name string, rtype protocol.RecordType) []byte {
 	packet := make([]byte, 0, 512)
 
 	// Header: QR=0 (query)
-	packet = append(packet, 0x00, 0x00)       // ID
-	packet = append(packet, 0x00, 0x00)       // Flags: QR=0 (query)
-	packet = append(packet, 0x00, 0x01)       // QDCOUNT=1
-	packet = append(packet, 0x00, 0x00)       // ANCOUNT=0
-	packet = append(packet, 0x00, 0x00)       // NSCOUNT=0
-	packet = append(packet, 0x00, 0x00)       // ARCOUNT=0
+	packet = append(packet, 0x00, 0x00) // ID
+	packet = append(packet, 0x00, 0x00) // Flags: QR=0 (query)
+	packet = append(packet, 0x00, 0x01) // QDCOUNT=1
+	packet = append(packet, 0x00, 0x00) // ANCOUNT=0
+	packet = append(packet, 0x00, 0x00) // NSCOUNT=0
+	packet = append(packet, 0x00, 0x00) // ARCOUNT=0
 
 	// Question section
 	nameEncoded, _ := message.EncodeName(name)
@@ -359,4 +359,125 @@ func buildQueryPacket(name string, rtype protocol.RecordType) []byte {
 	packet = append(packet, 0x00, 0x01) // CLASS=IN
 
 	return packet
+}
+
+// buildBundledPTRResponse builds a DNS-SD style response: a PTR answer for
+// serviceType plus SRV/TXT/A records in the ADDITIONAL section (the round-trip
+// optimization per RFC 6763 §12).
+func buildBundledPTRResponse(serviceType, instance, host string, port uint16, ip [4]byte, txt string) []byte {
+	ptrTarget, _ := message.EncodeName(instance)
+
+	srv := make([]byte, 6)
+	binary.BigEndian.PutUint16(srv[0:2], 0) // priority
+	binary.BigEndian.PutUint16(srv[2:4], 0) // weight
+	binary.BigEndian.PutUint16(srv[4:6], port)
+	hostEnc, _ := message.EncodeName(host)
+	srv = append(srv, hostEnc...)
+
+	txtRDATA := append([]byte{byte(len(txt))}, []byte(txt)...)
+
+	msg := &message.DNSMessage{
+		Header: message.DNSHeader{Flags: 0x8400}, // QR=1, AA=1
+		Answers: []message.Answer{
+			{NAME: serviceType, TYPE: uint16(protocol.RecordTypePTR), CLASS: 1, TTL: 120, RDATA: ptrTarget},
+		},
+		Additionals: []message.Answer{
+			{NAME: instance, TYPE: uint16(protocol.RecordTypeSRV), CLASS: 1, TTL: 120, RDATA: srv},
+			{NAME: instance, TYPE: uint16(protocol.RecordTypeTXT), CLASS: 1, TTL: 120, RDATA: txtRDATA},
+			{NAME: host, TYPE: uint16(protocol.RecordTypeA), CLASS: 1, TTL: 120, RDATA: ip[:]},
+		},
+	}
+	packet, _ := message.SerializeMessage(msg)
+	return packet
+}
+
+// TestCollectResponses_RetainsAdditionals verifies the Additional section is
+// retained in Response.Additionals (issue #4). Previously collectResponses
+// processed only the Answer section, discarding the SRV/TXT/A additionals that
+// let one PTR query resolve a whole instance.
+func TestCollectResponses_RetainsAdditionals(t *testing.T) {
+	q, err := New()
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	defer q.Close()
+
+	packet := buildBundledPTRResponse("_http._tcp.local", "Inst._http._tcp.local",
+		"host.local", 8080, [4]byte{192, 168, 1, 5}, "path=/api")
+	q.responseChan <- packet
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	resp, err := q.collectResponses(ctx, "_http._tcp.local", RecordTypePTR)
+	if err != nil {
+		t.Fatalf("collectResponses error: %v", err)
+	}
+
+	// Answer section: the PTR (queried type) is in Records as before.
+	if len(resp.Records) != 1 || resp.Records[0].Type != RecordTypePTR {
+		t.Fatalf("Records = %+v; want exactly one PTR record", resp.Records)
+	}
+
+	// Additional section: SRV/TXT/A must be retained (issue #4).
+	if len(resp.Additionals) != 3 {
+		t.Fatalf("Additionals has %d records, want 3 (SRV, TXT, A); additionals are being discarded", len(resp.Additionals))
+	}
+	var sawSRV, sawTXT, sawA bool
+	for _, r := range resp.Additionals {
+		switch r.Type {
+		case RecordTypeSRV:
+			sawSRV = true
+		case RecordTypeTXT:
+			sawTXT = true
+		case RecordTypeA:
+			sawA = true
+		}
+	}
+	if !sawSRV || !sawTXT || !sawA {
+		t.Fatalf("Additionals missing types: SRV=%v TXT=%v A=%v", sawSRV, sawTXT, sawA)
+	}
+}
+
+// TestDiscoverServices_UsesAdditionals_SingleRoundTrip verifies that when the
+// browse (PTR) response bundles SRV/TXT/A in its Additional section,
+// DiscoverServices resolves the instance from that single response WITHOUT
+// follow-up queries (issue #4). Only the bundled PTR packet is queued; if the
+// additionals were not consumed, the fallback SRV/TXT/A queries would find
+// nothing and the instance would be unresolved.
+func TestDiscoverServices_UsesAdditionals_SingleRoundTrip(t *testing.T) {
+	q, err := New()
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	defer q.Close()
+
+	packet := buildBundledPTRResponse("_http._tcp.local", "Inst._http._tcp.local",
+		"host.local", 8080, [4]byte{192, 168, 1, 5}, "path=/api")
+	q.responseChan <- packet
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	services, err := q.DiscoverServices(ctx, "_http._tcp.local")
+	if err != nil {
+		t.Fatalf("DiscoverServices error: %v", err)
+	}
+	if len(services) != 1 {
+		t.Fatalf("got %d services, want 1", len(services))
+	}
+	s := services[0]
+	if s.InstanceName != "Inst" {
+		t.Errorf("InstanceName = %q, want %q", s.InstanceName, "Inst")
+	}
+	if s.Hostname != "host.local" {
+		t.Errorf("Hostname = %q, want %q (must come from bundled SRV additional)", s.Hostname, "host.local")
+	}
+	if s.Port != 8080 {
+		t.Errorf("Port = %d, want 8080 (from bundled SRV additional)", s.Port)
+	}
+	if s.TXT["path"] != "/api" {
+		t.Errorf("TXT[path] = %q, want %q (from bundled TXT additional)", s.TXT["path"], "/api")
+	}
+	if s.AddrIPv4 == nil || s.AddrIPv4.String() != "192.168.1.5" {
+		t.Errorf("AddrIPv4 = %v, want 192.168.1.5 (from bundled A additional)", s.AddrIPv4)
+	}
 }

--- a/querier/querier.go
+++ b/querier/querier.go
@@ -318,35 +318,61 @@ func (q *Querier) DiscoverServices(ctx context.Context, serviceType string) ([]S
 			svc.InstanceName = target
 		}
 
-		// SRV query for hostname + port
-		srvCtx, srvCancel := context.WithTimeout(ctx, resolveTimeout)
-		srvResp, srvErr := q.Query(srvCtx, target, RecordTypeSRV)
-		srvCancel()
-		if srvErr == nil {
-			for _, r := range srvResp.Records {
-				if srv := r.AsSRV(); srv != nil {
-					svc.Hostname = srv.Target
-					svc.Port = srv.Port
-					break
-				}
+		// RFC 6763 §12: prefer SRV/TXT/A bundled in the browse response's
+		// additional section; fall back to explicit queries only for what is
+		// missing (issue #4 — saves up to 3 round-trips per instance).
+		if rr := findInAdditionals(ptrResp.Additionals, target, RecordTypeSRV); rr != nil {
+			if srv := rr.AsSRV(); srv != nil {
+				svc.Hostname = srv.Target
+				svc.Port = srv.Port
 			}
 		}
-
-		// TXT query for metadata
-		txtCtx, txtCancel := context.WithTimeout(ctx, resolveTimeout)
-		txtResp, txtErr := q.Query(txtCtx, target, RecordTypeTXT)
-		txtCancel()
-		if txtErr == nil {
-			for _, r := range txtResp.Records {
-				if txt := r.AsTXT(); txt != nil {
-					svc.TXT = ParseTXT(txt)
-					break
-				}
+		if rr := findInAdditionals(ptrResp.Additionals, target, RecordTypeTXT); rr != nil {
+			if txt := rr.AsTXT(); txt != nil {
+				svc.TXT = ParseTXT(txt)
 			}
 		}
-
-		// A query for IPv4 address
 		if svc.Hostname != "" {
+			if rr := findInAdditionals(ptrResp.Additionals, svc.Hostname, RecordTypeA); rr != nil {
+				if ip := rr.AsA(); ip != nil {
+					svc.AddrIPv4 = ip
+				}
+			}
+		}
+
+		// Fallback: SRV query for hostname + port if not bundled as an additional.
+		if svc.Hostname == "" {
+			srvCtx, srvCancel := context.WithTimeout(ctx, resolveTimeout)
+			srvResp, srvErr := q.Query(srvCtx, target, RecordTypeSRV)
+			srvCancel()
+			if srvErr == nil {
+				for _, r := range srvResp.Records {
+					if srv := r.AsSRV(); srv != nil {
+						svc.Hostname = srv.Target
+						svc.Port = srv.Port
+						break
+					}
+				}
+			}
+		}
+
+		// Fallback: TXT query for metadata if not bundled as an additional.
+		if svc.TXT == nil {
+			txtCtx, txtCancel := context.WithTimeout(ctx, resolveTimeout)
+			txtResp, txtErr := q.Query(txtCtx, target, RecordTypeTXT)
+			txtCancel()
+			if txtErr == nil {
+				for _, r := range txtResp.Records {
+					if txt := r.AsTXT(); txt != nil {
+						svc.TXT = ParseTXT(txt)
+						break
+					}
+				}
+			}
+		}
+
+		// Fallback: A query for IPv4 if we have a hostname but no address yet.
+		if svc.Hostname != "" && svc.AddrIPv4 == nil {
 			aCtx, aCancel := context.WithTimeout(ctx, resolveTimeout)
 			aResp, aErr := q.Query(aCtx, svc.Hostname, RecordTypeA)
 			aCancel()
@@ -364,6 +390,35 @@ func (q *Querier) DiscoverServices(ctx context.Context, serviceType string) ([]S
 	}
 
 	return services, nil
+}
+
+// toRecordData normalizes parsed RDATA into the querier's public types.
+// message.ParseRDATA returns the internal message.SRVData for SRV records;
+// convert it to the public SRVData so ResourceRecord.AsSRV() works (the named
+// types are distinct, so without this the type assertion in AsSRV always fails
+// and SRV resolution silently yields nil). A/PTR/TXT already use shared types.
+func toRecordData(data interface{}) interface{} {
+	if srv, ok := data.(message.SRVData); ok {
+		return SRVData{
+			Priority: srv.Priority,
+			Weight:   srv.Weight,
+			Port:     srv.Port,
+			Target:   srv.Target,
+		}
+	}
+	return data
+}
+
+// findInAdditionals returns the first additional-section record matching the
+// given name and type, or nil. Used to resolve a service instance from records
+// bundled in a browse response (RFC 6763 §12) before falling back to queries.
+func findInAdditionals(additionals []ResourceRecord, name string, t RecordType) *ResourceRecord {
+	for i := range additionals {
+		if additionals[i].Type == t && additionals[i].Name == name {
+			return &additionals[i]
+		}
+	}
+	return nil
 }
 
 // collectResponses aggregates mDNS responses within the timeout window.
@@ -435,10 +490,42 @@ func (q *Querier) collectResponses(ctx context.Context, _ string, queryType Reco
 					Type:  RecordType(answer.TYPE),
 					Class: answer.CLASS,
 					TTL:   answer.TTL,
-					Data:  data,
+					Data:  toRecordData(data),
 				}
 
 				response.Records = append(response.Records, record)
+			}
+
+			// Retain Additional-section records (RFC 6763 §12). DNS-SD responders
+			// bundle SRV/TXT/A here so one PTR query resolves a whole instance;
+			// DiscoverServices consumes them to skip follow-up queries (issue #4).
+			//
+			// CAVEAT: ParseRDATA parses each RDATA slice in isolation, so names
+			// inside RDATA (SRV/PTR targets) that use DNS compression pointers
+			// (0xC0 back-references into the full message — common in Avahi/Bonjour
+			// responses) cannot be resolved and the record is skipped here; the
+			// query falls back to explicit lookups. Beacon's own responder does
+			// not compress, so beacon<->beacon discovery gets the single-round-trip
+			// path. Fixing cross-responder bundling needs ParseRDATA to take the
+			// full message + offset (tracked as a follow-up).
+			for _, add := range parsedMsg.Additionals {
+				data, err := message.ParseRDATA(add.TYPE, add.RDATA)
+				if err != nil {
+					continue
+				}
+				dedupeKey := fmt.Sprintf("add|%s|%d|%v", add.NAME, add.TYPE, data)
+				if seen[dedupeKey] {
+					continue
+				}
+				seen[dedupeKey] = true
+
+				response.Additionals = append(response.Additionals, ResourceRecord{
+					Name:  add.NAME,
+					Type:  RecordType(add.TYPE),
+					Class: add.CLASS,
+					TTL:   add.TTL,
+					Data:  toRecordData(data),
+				})
 			}
 		}
 	}

--- a/querier/querier.go
+++ b/querier/querier.go
@@ -214,6 +214,16 @@ func (q *Querier) Query(ctx context.Context, name string, recordType RecordType)
 	default:
 	}
 
+	// Honor the configured default timeout when the caller's context carries no
+	// deadline, so queries are always bounded. Without this, Query on a
+	// deadline-less context (e.g. context.Background()) blocks forever in
+	// collectResponses, and WithTimeout silently does nothing (issue #5).
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline && q.defaultTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, q.defaultTimeout)
+		defer cancel()
+	}
+
 	// FR-003: Validate name
 	err := protocol.ValidateName(name)
 	if err != nil {
@@ -232,13 +242,8 @@ func (q *Querier) Query(ctx context.Context, name string, recordType RecordType)
 		return nil, err
 	}
 
-	// FR-005: Send query to multicast group
-	// T033: Migrated from network.SendQuery to transport.Send()
-	mdnsAddr := &net.UDPAddr{
-		IP:   net.IPv4(224, 0, 0, 251),
-		Port: 5353,
-	}
-	err = q.transport.Send(ctx, queryMsg, mdnsAddr)
+	// FR-005: Send query to the mDNS multicast group (224.0.0.251:5353).
+	err = q.transport.Send(ctx, queryMsg, protocol.MulticastGroupIPv4())
 	if err != nil {
 		return nil, err // Already wrapped as NetworkError
 	}

--- a/querier/querier_test.go
+++ b/querier/querier_test.go
@@ -389,3 +389,37 @@ func ExampleQuerier_Query_services() {
 		}
 	}
 }
+
+// TestQuery_HonorsDefaultTimeout_DeadlinelessContext verifies that WithTimeout
+// actually bounds a query when the caller's context carries no deadline.
+//
+// Regression test for issue #5: defaultTimeout was set by WithTimeout but never
+// read by the query path, so Query(context.Background(), ...) blocked forever in
+// collectResponses (which only returns on ctx.Done()). The previous TestWithTimeout
+// only asserted the option SET the field, never that it was honored — which is
+// why this gap survived. A watchdog guards the test so a regression fails fast
+// instead of hanging the suite.
+func TestQuery_HonorsDefaultTimeout_DeadlinelessContext(t *testing.T) {
+	q, err := New(WithTimeout(150 * time.Millisecond))
+	if err != nil {
+		t.Fatalf("New(WithTimeout) failed: %v", err)
+	}
+	defer q.Close()
+
+	done := make(chan struct{})
+	start := time.Now()
+	go func() {
+		// context.Background() has NO deadline. WithTimeout must bound this.
+		_, _ = q.Query(context.Background(), "nonexistent-service.local", RecordTypeA)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		if elapsed := time.Since(start); elapsed > 1*time.Second {
+			t.Fatalf("Query took %v; WithTimeout(150ms) must bound a deadline-less context (issue #5)", elapsed)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Query did not return within 3s; WithTimeout is not honored for a deadline-less context (issue #5)")
+	}
+}

--- a/querier/records.go
+++ b/querier/records.go
@@ -60,6 +60,15 @@ type Response struct {
 	//
 	// Per FR-010, Authority records are ignored in M1.
 	Records []ResourceRecord
+
+	// Additionals contains records from the response's Additional section.
+	//
+	// DNS-SD responders bundle SRV/TXT/A records alongside a PTR answer to let a
+	// single query resolve a service instance without follow-up round-trips
+	// (RFC 6763 §12). These are kept separate from Records (which holds only
+	// answer-section records of the queried type) so existing callers are
+	// unaffected; DiscoverServices consumes them to avoid extra queries.
+	Additionals []ResourceRecord
 }
 
 // ResourceRecord represents a single DNS resource record from an mDNS response.

--- a/responder/handlequery_test.go
+++ b/responder/handlequery_test.go
@@ -304,7 +304,8 @@ func buildDNSQuery(qname string, qtype uint16) []byte {
 // Format: Each label is prefixed by a length byte, terminated by 0x00.
 //
 // Example: "_http._tcp.local" →
-//   []byte{5, '_', 'h', 't', 't', 'p', 4, '_', 't', 'c', 'p', 5, 'l', 'o', 'c', 'a', 'l', 0}
+//
+//	[]byte{5, '_', 'h', 't', 't', 'p', 4, '_', 't', 'c', 'p', 5, 'l', 'o', 'c', 'a', 'l', 0}
 func encodeDomainName(name string) []byte {
 	if name == "" || name == "." {
 		return []byte{0}

--- a/responder/lifecycle.go
+++ b/responder/lifecycle.go
@@ -1,0 +1,305 @@
+package responder
+
+import (
+	"fmt"
+
+	"github.com/joshuafuller/beacon/internal/message"
+	"github.com/joshuafuller/beacon/internal/protocol"
+	"github.com/joshuafuller/beacon/internal/records"
+	"github.com/joshuafuller/beacon/internal/state"
+)
+
+// maxRenameAttempts is the maximum number of times to rename a service on conflict.
+//
+// RFC 6762 §9: No explicit limit specified, but we use 10 as a reasonable maximum
+// to prevent infinite loops and resource exhaustion.
+//
+// FR-032: System MUST handle registration failures gracefully
+const maxRenameAttempts = 10
+
+// Register registers a service with probing and announcing per RFC 6762 §8.
+//
+// IMPORTANT: Register blocks for approximately 1.75 seconds while performing
+// the required probing (3 probes × 250ms) and announcing (2 announcements × 1s)
+// phases per RFC 6762 §8. Use a goroutine if non-blocking behavior is needed.
+//
+// Process:
+//  1. Validate service parameters
+//  2. Probe for name conflicts (RFC 6762 §8.1, ~750ms)
+//  3. Announce the service (RFC 6762 §8.3, ~1s)
+//  4. Add to registry on success
+//
+// If a naming conflict is detected during probing, the service is automatically
+// renamed per RFC 6762 §9 (e.g., "My Service" → "My Service-2") and probing
+// restarts, up to 10 attempts.
+//
+// Returns:
+//   - error: validation error, conflict error, max attempts error, or context error
+func (r *Responder) Register(service *Service) error {
+	if service == nil {
+		return fmt.Errorf("service cannot be nil")
+	}
+
+	// Validate service parameters
+	if err := service.Validate(); err != nil {
+		return err
+	}
+
+	// Set hostname if not provided
+	if service.Hostname == "" {
+		service.Hostname = r.hostname
+	}
+
+	// Get local IPv4 address (simplified - use first non-loopback)
+	ipv4, err := getLocalIPv4()
+	if err != nil {
+		return fmt.Errorf("failed to get local IPv4: %w", err)
+	}
+
+	// RFC 6762 §9: Rename loop on conflict (max 10 attempts)
+	// Attempt probing up to maxRenameAttempts times
+	for attempt := 1; attempt <= maxRenameAttempts; attempt++ {
+		// Build record set for this service (with current name)
+		serviceInfo := buildServiceInfo(service.InstanceName, service.ServiceType,
+			service.Hostname, service.Port, ipv4, service.TXTRecords)
+		recordSet := records.BuildRecordSet(serviceInfo)
+
+		// US2 GREEN: Store record set for contract test validation
+		r.lastAnnouncedRecords = recordSet
+
+		// Create and run state machine
+		machine := state.NewMachine()
+		serviceName := service.InstanceName + "." + service.ServiceType
+
+		// Wire transport so probes and announcements are sent on the wire
+		machine.SetTransport(r.transport)
+
+		// Apply test hooks (if any)
+		if r.injectConflict {
+			machine.SetInjectConflict(true)
+		}
+
+		// US2 GREEN: Store machine for message capture (contract test support)
+		r.lastMachine = machine
+
+		// US2 GREEN: Apply callbacks to new machine (if any)
+		if r.onProbeCallback != nil {
+			prober := machine.GetProber()
+			if prober != nil {
+				prober.SetOnSendQuery(r.onProbeCallback)
+			}
+		}
+		if r.onAnnounceCallback != nil {
+			announcer := machine.GetAnnouncer()
+			if announcer != nil {
+				announcer.SetOnSendAnnouncement(r.onAnnounceCallback)
+			}
+		}
+
+		// Provide resource records to announcer for DNS message serialization
+		announcer := machine.GetAnnouncer()
+		if announcer != nil {
+			announcer.SetRecords(recordSet)
+		}
+
+		// Run state machine (probing + announcing)
+		err = machine.Run(r.ctx, serviceName)
+		if err != nil {
+			return fmt.Errorf("state machine failed: %w", err)
+		}
+
+		// Check final state
+		finalState := machine.GetState()
+
+		if finalState == state.StateConflictDetected {
+			// Conflict detected - rename and retry (unless max attempts reached)
+			if attempt >= maxRenameAttempts {
+				// Max attempts exceeded - give up
+				return fmt.Errorf("max rename attempts (%d) exceeded for service %q",
+					maxRenameAttempts, service.InstanceName)
+			}
+
+			// Rename service and try again
+			service.Rename() // Appends "-2", "-3", etc.
+			continue         // Retry with new name
+		}
+
+		if finalState != state.StateEstablished {
+			// This is NOT wrapping an error - finalState is state.State (int), not error type.
+			// Using %v here is correct for formatting the state value.
+			return fmt.Errorf("unexpected final state: %v", finalState) // nosemgrep: beacon-error-wrap-percent-v
+		}
+
+		// Success! Add to registry
+		// US5: toInternalService carries TXT records for UpdateService support
+		if err := r.registry.Register(toInternalService(service)); err != nil {
+			return fmt.Errorf("failed to add to registry: %w", err)
+		}
+
+		return nil // Successfully registered
+	}
+
+	// Should never reach here (loop returns on success or max attempts)
+	return fmt.Errorf("unexpected: register loop completed without result")
+}
+
+// Unregister unregisters a service and sends goodbye packets per RFC 6762 §10.1.
+//
+// RFC 6762 §10.1: "A host may send unsolicited responses with TTL=0 to announce
+// the departure of a record."
+//
+// Process:
+//  1. Remove from registry
+//  2. Send goodbye announcements (TTL=0)
+//
+// Returns:
+//   - error: if service not found or send fails
+//
+// T042: Implement Unregister() with goodbye packets
+func (r *Responder) Unregister(serviceID string) error {
+	// Lookup service to get instance name (handles both full ID and instance name)
+	svc, found := r.GetService(serviceID)
+	if !found {
+		return fmt.Errorf("service %q not registered", serviceID)
+	}
+
+	// Get local IPv4 address for goodbye records
+	ipv4, err := getLocalIPv4()
+	if err != nil {
+		// If we can't get IP, still remove from registry but skip goodbye
+		_ = r.registry.Remove(svc.InstanceName) // nosemgrep: beacon-error-swallowing
+		return fmt.Errorf("failed to get local IP for goodbye: %w", err)
+	}
+
+	// Build goodbye records with TTL=0 (RFC 6762 §10.1)
+	serviceInfo := buildServiceInfo(svc.InstanceName, svc.ServiceType,
+		r.hostname, svc.Port, ipv4, svc.TXTRecords)
+	goodbyeRecords := records.BuildGoodbyeRecords(serviceInfo)
+
+	// Build and send goodbye packet
+	goodbyePacket, err := message.BuildResponse(goodbyeRecords)
+	if err != nil {
+		// If we can't build packet, still remove from registry
+		_ = r.registry.Remove(svc.InstanceName) // nosemgrep: beacon-error-swallowing
+		return fmt.Errorf("failed to build goodbye packet: %w", err)
+	}
+
+	// RFC 6762 §10.1: Goodbye is best-effort (SHOULD, not MUST).
+	// Ignore send errors; we still remove from the registry below.
+	_ = r.transport.Send(r.ctx, goodbyePacket, protocol.MulticastGroupIPv4()) // nosemgrep: beacon-error-swallowing
+
+	// Remove from registry using instance name
+	if err := r.registry.Remove(svc.InstanceName); err != nil {
+		return fmt.Errorf("service %q not registered", serviceID)
+	}
+
+	return nil
+}
+
+// GetService retrieves a registered service by service ID.
+//
+// The serviceID can be either:
+//   - Full service ID: "Instance Name._service._proto.local"
+//   - Just instance name: "Instance Name" (backward compatibility)
+//
+// Returns:
+//   - *Service: The service if found
+//   - bool: true if service exists, false otherwise
+//
+// T100: Implement GetService for multi-service support (US5 GREEN)
+func (r *Responder) GetService(serviceID string) (*Service, bool) {
+	// Try lookup by instance name directly (works if serviceID is just the instance name)
+	if svc, found := r.registry.Get(serviceID); found {
+		return fromInternalService(svc), true
+	}
+
+	// serviceID might be full DNS name "Instance._service._proto.local"
+	// Extract instance name (everything before first dot)
+	// For now, iterate through all services and find matching one
+	for _, instanceName := range r.registry.List() {
+		svc, found := r.registry.Get(instanceName)
+		if !found {
+			continue
+		}
+
+		// Build full service ID and compare
+		fullID := svc.InstanceName + "." + svc.ServiceType
+		if fullID == serviceID {
+			return fromInternalService(svc), true
+		}
+	}
+
+	return nil, false
+}
+
+// UpdateService updates a registered service's TXT records without re-probing.
+//
+// Per RFC 6762 §8.4, updating TXT records does NOT require re-probing since:
+// - The service instance name hasn't changed (no conflict possible)
+// - TXT records are metadata, not part of the unique service identity
+//
+// Process:
+//  1. Find service in registry
+//  2. Update TXT records
+//  3. Send announcement with updated TXT record (multicast to inform network)
+//
+// Parameters:
+//   - serviceID: Service identifier (InstanceName or InstanceName.ServiceType)
+//   - txtRecords: New TXT records to set
+//
+// Returns:
+//   - error: If service not found or update fails
+//
+// T106: Implement UpdateService without re-probing (US5 GREEN)
+func (r *Responder) UpdateService(serviceID string, txtRecords map[string]string) error {
+	// Lookup service
+	svc, found := r.GetService(serviceID)
+	if !found {
+		return fmt.Errorf("service %q not found", serviceID)
+	}
+
+	// Update TXT records in registry
+	// The registry stores internal/responder.Service, so we need to update it there
+	internalSvc, found := r.registry.Get(svc.InstanceName)
+	if !found {
+		return fmt.Errorf("internal error: service %q in GetService but not in registry", svc.InstanceName)
+	}
+
+	// Update TXT records
+	internalSvc.TXT = txtRecords
+
+	// Announce updated records per RFC 6762 §8.4.
+	// The registry is already updated above; the multicast announcement below is
+	// best-effort (RFC 6762 §8.4 is a SHOULD), so failures to obtain an address,
+	// build, or send the packet do not roll back the update.
+	ipv4, err := getLocalIPv4()
+	if err != nil {
+		return nil // Registry updated; cannot announce without an IP (best-effort).
+	}
+
+	serviceInfo := buildServiceInfo(svc.InstanceName, svc.ServiceType,
+		r.hostname, svc.Port, ipv4, txtRecords)
+	announcedRecords := records.BuildRecordSet(serviceInfo)
+
+	// Convert to message.ResourceRecord for BuildResponse
+	msgRecords := make([]*message.ResourceRecord, len(announcedRecords))
+	for i, rr := range announcedRecords {
+		msgRecords[i] = &message.ResourceRecord{
+			Name:       rr.Name,
+			Type:       rr.Type,
+			Class:      rr.Class,
+			TTL:        rr.TTL,
+			Data:       rr.Data,
+			CacheFlush: rr.CacheFlush,
+		}
+	}
+
+	responseBytes, err := message.BuildResponse(msgRecords)
+	if err != nil {
+		return nil // Registry updated, announcement failed - best effort
+	}
+
+	_ = r.transport.Send(r.ctx, responseBytes, protocol.MulticastGroupIPv4()) // nosemgrep: beacon-error-swallowing
+
+	return nil
+}

--- a/responder/query_handler.go
+++ b/responder/query_handler.go
@@ -1,0 +1,365 @@
+package responder
+
+import (
+	"net"
+
+	"github.com/joshuafuller/beacon/internal/message"
+	"github.com/joshuafuller/beacon/internal/protocol"
+	"github.com/joshuafuller/beacon/internal/responder"
+)
+
+// runQueryHandler continuously receives and processes mDNS queries.
+//
+// RFC 6762 §6: Responders SHOULD respond to queries for services they have registered.
+//
+// Process:
+//  1. Receive query packet from transport
+//  2. Parse DNS message
+//  3. For each question, check if we have matching service
+//  4. Build response (PTR answer + SRV/TXT/A additional)
+//  5. Apply rate limiting per RFC 6762 §6.2
+//  6. Send response (unicast or multicast based on QU bit)
+//
+// T080: Query handler goroutine
+func (r *Responder) runQueryHandler() {
+	defer r.queryHandlerWg.Done()
+	for {
+		select {
+		case <-r.ctx.Done():
+			return
+		case <-r.queryHandlerDone:
+			return
+		default:
+			// Receive query with timeout
+			// 007-interface-specific-addressing T027: Extract interfaceIndex for RFC 6762 §15 compliance
+			// Task 2: Capture source address for subnet validation (RFC 6762 §6.4)
+			packet, srcAddr, interfaceIndex, err := r.transport.Receive(r.ctx)
+			if err != nil {
+				// Context cancelled or transport closed
+				select {
+				case <-r.ctx.Done():
+					return
+				case <-r.queryHandlerDone:
+					return
+				default:
+					// Other error - continue receiving
+					continue
+				}
+			}
+
+			// Handle query (T079)
+			// T028: Pass interfaceIndex to enable interface-specific addressing
+			// Task 2: Pass source address for subnet validation
+			_ = r.handleQuery(packet, srcAddr, interfaceIndex)
+		}
+	}
+}
+
+// validateSourceAddress validates that the query source is on the same subnet as the interface.
+//
+// RFC 6762 §6.4: "When a Multicast DNS responder receives a query, it MUST only respond
+// if the source address of the query is on the same subnet as the interface on which
+// the query was received."
+//
+// Parameters:
+//   - srcAddr: Source address of the query
+//   - interfaceIndex: OS interface index that received the query
+//
+// Returns:
+//   - bool: true if source is on same subnet, false otherwise
+//
+// Task 2: Source address validation
+func validateSourceAddress(srcAddr net.Addr, interfaceIndex int) bool {
+	// If interface index is unknown (0), skip validation (graceful degradation)
+	if interfaceIndex == 0 {
+		return true
+	}
+
+	// Extract IP from source address
+	udpAddr, ok := srcAddr.(*net.UDPAddr)
+	if !ok {
+		return false
+	}
+	srcIP := udpAddr.IP.To4()
+	if srcIP == nil {
+		return false // Not IPv4
+	}
+
+	// Get interface by index
+	iface, err := net.InterfaceByIndex(interfaceIndex)
+	if err != nil {
+		return false
+	}
+
+	// Get interface addresses
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return false
+	}
+
+	// Check if source IP is on same subnet as any interface address
+	for _, addr := range addrs {
+		ipnet, ok := addr.(*net.IPNet)
+		if !ok {
+			continue
+		}
+
+		// Check if source IP is in this subnet
+		if ipnet.Contains(srcIP) {
+			return true
+		}
+	}
+
+	// Source IP not on same subnet
+	return false
+}
+
+// handleQuery processes a single mDNS query and sends response.
+//
+// RFC 6762 §6: "When a Multicast DNS responder receives a query, it must determine
+// whether the query is requesting information for which this responder is authoritative."
+//
+// RFC 6762 §6.4: "When a Multicast DNS responder receives a query, it MUST only respond
+// if the source address of the query is on the same subnet as the interface on which
+// the query was received."
+//
+// RFC 6762 §15: Responses MUST include only addresses valid on the receiving interface,
+// and MUST NOT include addresses from other interfaces.
+//
+// Process:
+//  1. Parse query message
+//  2. Validate source address (RFC 6762 §6.4)
+//  3. Extract questions
+//  4. Check if we have matching registered services
+//  5. Build response using ResponseBuilder with interface-specific IP (T029)
+//  6. Apply QU bit logic (unicast vs multicast)
+//  7. Apply rate limiting (RFC 6762 §6.2)
+//  8. Send response
+//
+// Parameters:
+//   - packet: DNS query in wire format
+//   - srcAddr: Source address of the query
+//   - interfaceIndex: OS interface index that received the query (0 = unknown)
+//
+// Returns:
+//   - error: parse error or send error (logged, not propagated)
+//
+// T079: Implement handleQuery()
+// T029: Added interfaceIndex parameter for interface-specific addressing
+// Task 2: Added srcAddr parameter for source address validation
+func (r *Responder) handleQuery(packet []byte, srcAddr net.Addr, interfaceIndex int) error {
+	// Task 2: RFC 6762 §6.4 - Validate source address is on same subnet
+	if !validateSourceAddress(srcAddr, interfaceIndex) {
+		// Source not on same subnet - ignore query per RFC 6762 §6.4
+		return nil
+	}
+
+	// Import message parser
+	msg, err := parseMessage(packet)
+	if err != nil {
+		// Malformed query - ignore per RFC 6762 §6
+		return err
+	}
+
+	// Ignore responses (QR=1)
+	if msg.Header.IsResponse() {
+		return nil
+	}
+
+	// DNS-SD meta-query name per RFC 6763 §9
+	const serviceEnumerationName = "_services._dns-sd._udp.local"
+
+	// Process each question
+	for _, question := range msg.Questions {
+		// RFC 6763 §9: Service Type Enumeration
+		// A PTR query for "_services._dns-sd._udp.local" returns all unique service types.
+		if question.QTYPE == uint16(protocol.RecordTypePTR) && question.QNAME == serviceEnumerationName {
+			serviceTypes := r.registry.ListServiceTypes()
+			if len(serviceTypes) == 0 {
+				continue // No services registered, no response needed
+			}
+
+			// Build PTR records: one for each unique service type
+			ptrRecords := make([]*message.ResourceRecord, 0, len(serviceTypes))
+			for _, svcType := range serviceTypes {
+				// RDATA for PTR record is the encoded service type name
+				encodedTarget, encErr := message.EncodeName(svcType)
+				if encErr != nil {
+					continue // Skip types that cannot be encoded
+				}
+				ptrRecords = append(ptrRecords, &message.ResourceRecord{
+					Name:       serviceEnumerationName,
+					Type:       protocol.RecordTypePTR,
+					Class:      protocol.ClassIN,
+					TTL:        protocol.TTLHostname, // 4500s per RFC 6762 §10
+					Data:       encodedTarget,
+					CacheFlush: false, // PTR is a shared record
+				})
+			}
+
+			if len(ptrRecords) == 0 {
+				continue
+			}
+
+			// Build DNS response message
+			responseMsg, buildErr := message.BuildResponse(ptrRecords)
+			if buildErr != nil {
+				continue
+			}
+
+			// Determine destination (unicast vs multicast based on QU bit)
+			quBit := (question.QCLASS & 0x8000) != 0
+			var dest net.Addr
+			if quBit {
+				dest = srcAddr
+			}
+			// nil dest = multicast to 224.0.0.251:5353
+
+			_ = r.transport.Send(r.ctx, responseMsg, dest)
+			continue
+		}
+
+		// Get all registered services
+		services := r.registry.List()
+
+		var matchedService *responder.Service
+		for _, instanceName := range services {
+			service, found := r.registry.Get(instanceName)
+			if !found {
+				continue
+			}
+
+			switch question.QTYPE {
+			case uint16(protocol.RecordTypePTR):
+				// PTR: match by service type (e.g., "_http._tcp.local")
+				if service.ServiceType == question.QNAME {
+					matchedService = service
+				}
+			case uint16(protocol.RecordTypeSRV), uint16(protocol.RecordTypeTXT):
+				// SRV/TXT: match by full instance name (e.g., "My Printer._http._tcp.local")
+				fullName := service.InstanceName + "." + service.ServiceType
+				if fullName == question.QNAME {
+					matchedService = service
+				}
+			case uint16(protocol.RecordTypeA):
+				// A: match by hostname (e.g., "myhost.local")
+				if r.hostname == question.QNAME {
+					matchedService = service
+				}
+			}
+
+			if matchedService != nil {
+				break
+			}
+		}
+
+		if matchedService == nil {
+			continue
+		}
+
+		// We have a match! Build response with interface-specific addressing
+		//
+		// RFC 6762 §15 "Responding to Address Queries":
+		// "When a Multicast DNS responder sends a Multicast DNS response message
+		// containing its own address records in response to a query received on
+		// a particular interface, it MUST include only addresses that are valid
+		// on that interface, and MUST NOT include addresses configured on other
+		// interfaces."
+		//
+		// T036: Inline comment citing RFC 6762 §15
+		var ipv4 []byte
+		var ipErr error
+
+		// T030: Graceful fallback when interface index unavailable (interfaceIndex=0)
+		// This happens when control messages aren't supported or platform doesn't provide IP_PKTINFO
+		if interfaceIndex == 0 {
+			// Degraded mode: Use default interface IP (legacy behavior)
+			// TODO T032: Add debug logging when F-6 (Logging & Observability) is implemented
+			ipv4, ipErr = getLocalIPv4()
+		} else {
+			// RFC 6762 §15 compliance: Use ONLY the IP from the receiving interface
+			ipv4, ipErr = getIPv4ForInterface(interfaceIndex)
+		}
+
+		if ipErr != nil {
+			// T031: If interface-specific IP lookup fails, skip response for this query
+			// This is correct behavior per RFC 6762 §15: Better to not respond than
+			// to respond with an incorrect (wrong interface) IP address
+			// TODO T032: Add error logging when F-6 is implemented
+			// Common failure causes: interface went down, no IPv4 configured, invalid index
+			continue
+		}
+
+		serviceWithIP := &responder.ServiceWithIP{
+			InstanceName: matchedService.InstanceName,
+			ServiceType:  matchedService.ServiceType,
+			Domain:       "local",
+			Port:         matchedService.Port,
+			IPv4Address:  ipv4,
+			TXTRecords:   matchedService.TXT, // internal.Service uses TXT field
+			Hostname:     r.hostname,
+		}
+
+		// Build response (T076)
+		response, err := r.responseBuilder.BuildResponse(serviceWithIP, msg)
+		if err != nil {
+			continue
+		}
+
+		// Per-source-IP rate limiting (FR-026, RFC 6762 §6.2)
+		if r.rateLimiter != nil && srcAddr != nil {
+			srcIP := srcAddr.String()
+			if udpAddr, ok := srcAddr.(*net.UDPAddr); ok {
+				srcIP = udpAddr.IP.String()
+			}
+			if !r.rateLimiter.Allow(srcIP) {
+				continue // Rate-limited, skip response
+			}
+		}
+
+		// RFC 6762 §5.4: Check QU bit (bit 15 of QCLASS) to determine unicast vs multicast
+		// Task 4: QU bit handling
+		quBit := (question.QCLASS & 0x8000) != 0
+
+		var dest net.Addr
+		if quBit {
+			// RFC 6762 §5.4: QU bit set → send unicast response to querier
+			dest = srcAddr
+		} else {
+			// RFC 6762 §5.4: QU bit clear → send multicast response
+			dest = nil // nil = multicast to 224.0.0.251:5353
+		}
+
+		// Send response
+		responsePacket := buildResponsePacket(response)
+		_ = r.transport.Send(r.ctx, responsePacket, dest)
+	}
+
+	return nil
+}
+
+// parseMessage is a wrapper around message.ParseMessage for easier imports.
+func parseMessage(packet []byte) (*message.DNSMessage, error) {
+	return message.ParseMessage(packet)
+}
+
+// buildResponsePacket serializes a DNSMessage to wire format using message.SerializeMessage.
+//
+// RFC 1035 §4.1: Converts the complete DNSMessage struct (header, questions,
+// answers, authority, additional sections) into wire-format bytes.
+func buildResponsePacket(msg *message.DNSMessage) []byte {
+	data, err := message.SerializeMessage(msg)
+	if err != nil {
+		// Serialization failed - return minimal valid DNS response header
+		// so the responder doesn't crash on unexpected serialization errors
+		return []byte{
+			0x00, 0x00, // ID
+			0x84, 0x00, // Flags (QR=1, AA=1)
+			0x00, 0x00, // QDCount
+			0x00, 0x00, // ANCount
+			0x00, 0x00, // NSCount
+			0x00, 0x00, // ARCount
+		}
+	}
+	return data
+}

--- a/responder/responder.go
+++ b/responder/responder.go
@@ -6,12 +6,9 @@ import (
 	"net"
 	"os"
 	"sync"
-
 	"time"
 
 	"github.com/joshuafuller/beacon/internal/errors"
-	"github.com/joshuafuller/beacon/internal/message"
-	"github.com/joshuafuller/beacon/internal/protocol"
 	"github.com/joshuafuller/beacon/internal/records"
 	"github.com/joshuafuller/beacon/internal/responder"
 	"github.com/joshuafuller/beacon/internal/security"
@@ -34,6 +31,12 @@ import (
 // If interface information is unavailable (e.g., on Windows or older kernels),
 // the responder falls back to advertising the default interface IP.
 //
+// The implementation is split across several files in this package:
+//   - responder.go      lifecycle scaffolding (struct, New, Close) and IP/dedup helpers
+//   - lifecycle.go      service management (Register, Unregister, Get, Update)
+//   - query_handler.go  incoming-query processing (RFC 6762 §6)
+//   - testhooks.go      test-only observation/injection hooks (see file header)
+//
 // T035: Responder struct
 // T080: Added query handler goroutine support
 // T082: Added interface-specific addressing documentation
@@ -43,20 +46,18 @@ type Responder struct {
 	registry         *responder.Registry
 	hostname         string
 	queryHandlerWg   sync.WaitGroup             // Synchronize query handler goroutine shutdown
-	injectConflict   bool                       // Test hook: inject conflict during probing
 	responseBuilder  *responder.ResponseBuilder // RFC 6762 §6 response construction
 	recordSet        *records.RecordSet         // Per-record rate limiting tracker
 	rateLimiter      *security.RateLimiter      // Per-source-IP rate limiting (FR-026)
 	queryHandlerDone chan struct{}              // Signal query handler shutdown
 
-	// US2 GREEN: Store last machine for message capture (contract test support)
-	lastMachine *state.Machine // Last state machine used for registration
-
-	// US2 GREEN: Store callbacks for applying to new machines
-	onProbeCallback    func() // Callback for probe events
-	onAnnounceCallback func() // Callback for announce events
-
-	// US2 GREEN: Store last announced records for contract test validation
+	// Test-only state. These fields exist solely to support black-box contract
+	// tests (see testhooks.go); they are not part of the responder's runtime
+	// behavior. Production code paths never read them except where guarded.
+	injectConflict       bool              // Inject conflict during probing
+	lastMachine          *state.Machine    // Last state machine used for registration
+	onProbeCallback      func()            // Callback for probe events
+	onAnnounceCallback   func()            // Callback for announce events
 	lastAnnouncedRecords []*ResourceRecord // Last record set announced
 }
 
@@ -103,218 +104,6 @@ func New(ctx context.Context, opts ...Option) (*Responder, error) {
 	return r, nil
 }
 
-// maxRenameAttempts is the maximum number of times to rename a service on conflict.
-//
-// RFC 6762 §9: No explicit limit specified, but we use 10 as a reasonable maximum
-// to prevent infinite loops and resource exhaustion.
-//
-// FR-032: System MUST handle registration failures gracefully
-const maxRenameAttempts = 10
-
-// Register registers a service with probing and announcing per RFC 6762 §8.
-//
-// IMPORTANT: Register blocks for approximately 1.75 seconds while performing
-// the required probing (3 probes × 250ms) and announcing (2 announcements × 1s)
-// phases per RFC 6762 §8. Use a goroutine if non-blocking behavior is needed.
-//
-// Process:
-//  1. Validate service parameters
-//  2. Probe for name conflicts (RFC 6762 §8.1, ~750ms)
-//  3. Announce the service (RFC 6762 §8.3, ~1s)
-//  4. Add to registry on success
-//
-// If a naming conflict is detected during probing, the service is automatically
-// renamed per RFC 6762 §9 (e.g., "My Service" → "My Service-2") and probing
-// restarts, up to 10 attempts.
-//
-// Returns:
-//   - error: validation error, conflict error, max attempts error, or context error
-func (r *Responder) Register(service *Service) error {
-	if service == nil {
-		return fmt.Errorf("service cannot be nil")
-	}
-
-	// Validate service parameters
-	if err := service.Validate(); err != nil {
-		return err
-	}
-
-	// Set hostname if not provided
-	if service.Hostname == "" {
-		service.Hostname = r.hostname
-	}
-
-	// Get local IPv4 address (simplified - use first non-loopback)
-	ipv4, err := getLocalIPv4()
-	if err != nil {
-		return fmt.Errorf("failed to get local IPv4: %w", err)
-	}
-
-	// RFC 6762 §9: Rename loop on conflict (max 10 attempts)
-	// Attempt probing up to maxRenameAttempts times
-	for attempt := 1; attempt <= maxRenameAttempts; attempt++ {
-		// Build record set for this service (with current name)
-		serviceInfo := &records.ServiceInfo{
-			InstanceName: service.InstanceName,
-			ServiceType:  service.ServiceType,
-			Hostname:     service.Hostname,
-			Port:         service.Port,
-			IPv4Address:  ipv4,
-			TXTRecords:   service.TXTRecords,
-		}
-		recordSet := records.BuildRecordSet(serviceInfo)
-
-		// US2 GREEN: Store record set for contract test validation
-		r.lastAnnouncedRecords = recordSet
-
-		// Create and run state machine
-		machine := state.NewMachine()
-		serviceName := service.InstanceName + "." + service.ServiceType
-
-		// Wire transport so probes and announcements are sent on the wire
-		machine.SetTransport(r.transport)
-
-		// Apply test hooks (if any)
-		if r.injectConflict {
-			machine.SetInjectConflict(true)
-		}
-
-		// US2 GREEN: Store machine for message capture (contract test support)
-		r.lastMachine = machine
-
-		// US2 GREEN: Apply callbacks to new machine (if any)
-		if r.onProbeCallback != nil {
-			prober := machine.GetProber()
-			if prober != nil {
-				prober.SetOnSendQuery(r.onProbeCallback)
-			}
-		}
-		if r.onAnnounceCallback != nil {
-			announcer := machine.GetAnnouncer()
-			if announcer != nil {
-				announcer.SetOnSendAnnouncement(r.onAnnounceCallback)
-			}
-		}
-
-		// Provide resource records to announcer for DNS message serialization
-		announcer := machine.GetAnnouncer()
-		if announcer != nil {
-			announcer.SetRecords(recordSet)
-		}
-
-		// Run state machine (probing + announcing)
-		err = machine.Run(r.ctx, serviceName)
-		if err != nil {
-			return fmt.Errorf("state machine failed: %w", err)
-		}
-
-		// Check final state
-		finalState := machine.GetState()
-
-		if finalState == state.StateConflictDetected {
-			// Conflict detected - rename and retry (unless max attempts reached)
-			if attempt >= maxRenameAttempts {
-				// Max attempts exceeded - give up
-				return fmt.Errorf("max rename attempts (%d) exceeded for service %q",
-					maxRenameAttempts, service.InstanceName)
-			}
-
-			// Rename service and try again
-			service.Rename() // Appends "-2", "-3", etc.
-			continue         // Retry with new name
-		}
-
-		if finalState != state.StateEstablished {
-			// This is NOT wrapping an error - finalState is state.State (int), not error type.
-			// Using %v here is correct for formatting the state value.
-			return fmt.Errorf("unexpected final state: %v", finalState) // nosemgrep: beacon-error-wrap-percent-v
-		}
-
-		// Success! Add to registry
-		internalService := &responder.Service{
-			InstanceName: service.InstanceName,
-			ServiceType:  service.ServiceType,
-			Port:         service.Port,
-			TXT:          service.TXTRecords, // US5: Store TXT records for UpdateService support
-		}
-		err = r.registry.Register(internalService)
-		if err != nil {
-			return fmt.Errorf("failed to add to registry: %w", err)
-		}
-
-		return nil // Successfully registered
-	}
-
-	// Should never reach here (loop returns on success or max attempts)
-	return fmt.Errorf("unexpected: register loop completed without result")
-}
-
-// Unregister unregisters a service and sends goodbye packets per RFC 6762 §10.1.
-//
-// RFC 6762 §10.1: "A host may send unsolicited responses with TTL=0 to announce
-// the departure of a record."
-//
-// Process:
-//  1. Remove from registry
-//  2. Send goodbye announcements (TTL=0)
-//
-// Returns:
-//   - error: if service not found or send fails
-//
-// T042: Implement Unregister() with goodbye packets
-func (r *Responder) Unregister(serviceID string) error {
-	// Lookup service to get instance name (handles both full ID and instance name)
-	svc, found := r.GetService(serviceID)
-	if !found {
-		return fmt.Errorf("service %q not registered", serviceID)
-	}
-
-	// Get local IPv4 address for goodbye records
-	ipv4, err := getLocalIPv4()
-	if err != nil {
-		// If we can't get IP, still remove from registry but skip goodbye
-		_ = r.registry.Remove(svc.InstanceName) // nosemgrep: beacon-error-swallowing
-		return fmt.Errorf("failed to get local IP for goodbye: %w", err)
-	}
-
-	// Build goodbye records with TTL=0 (RFC 6762 §10.1)
-	serviceInfo := &records.ServiceInfo{
-		InstanceName: svc.InstanceName,
-		ServiceType:  svc.ServiceType,
-		Hostname:     r.hostname,
-		Port:         svc.Port,
-		IPv4Address:  ipv4,
-		TXTRecords:   svc.TXTRecords,
-	}
-	goodbyeRecords := records.BuildGoodbyeRecords(serviceInfo)
-
-	// Build and send goodbye packet
-	goodbyePacket, err := message.BuildResponse(goodbyeRecords)
-	if err != nil {
-		// If we can't build packet, still remove from registry
-		_ = r.registry.Remove(svc.InstanceName) // nosemgrep: beacon-error-swallowing
-		return fmt.Errorf("failed to build goodbye packet: %w", err)
-	}
-
-	dest := &net.UDPAddr{
-		IP:   net.ParseIP("224.0.0.251"),
-		Port: 5353,
-	}
-	// RFC 6762 §10.1: Goodbye is best-effort (SHOULD, not MUST).
-	// Log but don't fail if send errors.
-	if err := r.transport.Send(r.ctx, goodbyePacket, dest); err != nil { // nosemgrep: beacon-error-swallowing
-		// Best-effort: goodbye failed but we still remove from registry below
-		_ = err
-	}
-
-	// Remove from registry using instance name
-	if err := r.registry.Remove(svc.InstanceName); err != nil {
-		return fmt.Errorf("service %q not registered", serviceID)
-	}
-
-	return nil
-}
-
 // Close closes the responder and unregisters all services per FR-015.
 //
 // Process:
@@ -351,6 +140,56 @@ func (r *Responder) Close() error {
 	r.queryHandlerWg.Wait()
 
 	return closeErr
+}
+
+// ResourceRecord is a type alias for records.ResourceRecord.
+//
+// This alias allows contract tests to reference ResourceRecord without importing
+// the internal records package directly, maintaining clean architecture boundaries.
+//
+// The underlying type contains DNS resource record fields:
+//   - Name: Domain name (e.g., "myservice._http._tcp.local")
+//   - Type: Record type (A, PTR, SRV, TXT per RFC 1035)
+//   - Class: Record class (IN for Internet)
+//   - TTL: Time-to-live in seconds
+//   - Data: Record-specific data (IP address, target name, etc.)
+//   - CacheFlush: Cache-flush bit per RFC 6762 §10.2
+//
+// US2 GREEN: Contract test support for validating resource records
+type ResourceRecord = records.ResourceRecord
+
+// buildServiceInfo assembles a records.ServiceInfo from individual service
+// fields. Shared by Register, Unregister, and UpdateService so the record-set
+// inputs are constructed in exactly one place.
+func buildServiceInfo(instanceName, serviceType, hostname string, port uint16, ipv4 []byte, txt map[string]string) *records.ServiceInfo {
+	return &records.ServiceInfo{
+		InstanceName: instanceName,
+		ServiceType:  serviceType,
+		Hostname:     hostname,
+		Port:         port,
+		IPv4Address:  ipv4,
+		TXTRecords:   txt,
+	}
+}
+
+// toInternalService converts a public Service to the internal registry type.
+func toInternalService(s *Service) *responder.Service {
+	return &responder.Service{
+		InstanceName: s.InstanceName,
+		ServiceType:  s.ServiceType,
+		Port:         s.Port,
+		TXT:          s.TXTRecords,
+	}
+}
+
+// fromInternalService converts an internal registry Service to the public type.
+func fromInternalService(s *responder.Service) *Service {
+	return &Service{
+		InstanceName: s.InstanceName,
+		ServiceType:  s.ServiceType,
+		Port:         s.Port,
+		TXTRecords:   s.TXT,
+	}
 }
 
 // getLocalIPv4 gets the first non-loopback IPv4 address from any interface.
@@ -417,8 +256,6 @@ func getLocalIPv4() ([]byte, error) {
 //	    // Handle error: skip response or fall back to getLocalIPv4()
 //	}
 //	// Use ipv4 in A record for mDNS response
-//
-//lint:ignore U1000 T020: Foundation for T027-T033 (Phase 3 GREEN), will be used in handleQuery()
 func getIPv4ForInterface(ifIndex int) ([]byte, error) {
 	// T015: Look up interface by index
 	iface, err := net.InterfaceByIndex(ifIndex)
@@ -456,632 +293,4 @@ func getIPv4ForInterface(ifIndex int) ([]byte, error) {
 		Value:   iface.Name,
 		Message: "no IPv4 address found on interface",
 	}
-}
-
-// OnProbe sets a callback to be called when a probe is sent.
-//
-// US2 GREEN: Contract test support for RFC 6762 §8.1 validation
-func (r *Responder) OnProbe(callback func()) {
-	// Store callback for future machines
-	r.onProbeCallback = callback
-
-	// Also apply to current machine if it exists
-	if r.lastMachine != nil {
-		prober := r.lastMachine.GetProber()
-		if prober != nil {
-			prober.SetOnSendQuery(callback)
-		}
-	}
-}
-
-// OnAnnounce sets a callback to be called when an announcement is sent.
-//
-// US2 GREEN: Contract test support for RFC 6762 §8.3 validation
-func (r *Responder) OnAnnounce(callback func()) {
-	// Store callback for future machines
-	r.onAnnounceCallback = callback
-
-	// Also apply to current machine if it exists
-	if r.lastMachine != nil {
-		announcer := r.lastMachine.GetAnnouncer()
-		if announcer != nil {
-			announcer.SetOnSendAnnouncement(callback)
-		}
-	}
-}
-
-// GetLastProbeMessage returns the last sent probe message.
-//
-// US2 GREEN: Contract test support for RFC 6762 §8.1 validation
-func (r *Responder) GetLastProbeMessage() []byte {
-	if r.lastMachine != nil {
-		prober := r.lastMachine.GetProber()
-		if prober != nil {
-			return prober.GetLastProbeMessage()
-		}
-	}
-	return nil
-}
-
-// GetLastAnnounceMessage returns the last sent announcement message.
-//
-// US2 GREEN: Contract test support for RFC 6762 §8.3 validation
-func (r *Responder) GetLastAnnounceMessage() []byte {
-	if r.lastMachine != nil {
-		announcer := r.lastMachine.GetAnnouncer()
-		if announcer != nil {
-			return announcer.GetLastAnnounceMessage()
-		}
-	}
-	return nil
-}
-
-// GetLastAnnouncedRecords returns the last announced record set.
-//
-// US2 GREEN: Contract test support for RFC 6762 §8.3 and RFC 6763 §6 validation
-func (r *Responder) GetLastAnnouncedRecords() []*ResourceRecord {
-	return r.lastAnnouncedRecords
-}
-
-// GetLastAnnounceDest returns the last announcement destination address.
-//
-// US2 GREEN: Contract test support for RFC 6762 §5 multicast address validation
-func (r *Responder) GetLastAnnounceDest() string {
-	if r.lastMachine != nil {
-		announcer := r.lastMachine.GetAnnouncer()
-		if announcer != nil {
-			return announcer.GetLastDestAddr()
-		}
-	}
-	return ""
-}
-
-// GetService retrieves a registered service by service ID.
-//
-// The serviceID can be either:
-//   - Full service ID: "Instance Name._service._proto.local"
-//   - Just instance name: "Instance Name" (backward compatibility)
-//
-// Returns:
-//   - *Service: The service if found
-//   - bool: true if service exists, false otherwise
-//
-// T100: Implement GetService for multi-service support (US5 GREEN)
-func (r *Responder) GetService(serviceID string) (*Service, bool) {
-	// Try lookup by instance name directly (works if serviceID is just the instance name)
-	if svc, found := r.registry.Get(serviceID); found {
-		// Convert internal Service to public Service
-		return &Service{
-			InstanceName: svc.InstanceName,
-			ServiceType:  svc.ServiceType,
-			Port:         svc.Port,
-			TXTRecords:   svc.TXT,
-		}, true
-	}
-
-	// serviceID might be full DNS name "Instance._service._proto.local"
-	// Extract instance name (everything before first dot)
-	// For now, iterate through all services and find matching one
-	for _, instanceName := range r.registry.List() {
-		svc, found := r.registry.Get(instanceName)
-		if !found {
-			continue
-		}
-
-		// Build full service ID and compare
-		fullID := svc.InstanceName + "." + svc.ServiceType
-		if fullID == serviceID {
-			return &Service{
-				InstanceName: svc.InstanceName,
-				ServiceType:  svc.ServiceType,
-				Port:         svc.Port,
-				TXTRecords:   svc.TXT,
-			}, true
-		}
-	}
-
-	return nil, false
-}
-
-// UpdateService updates a registered service's TXT records without re-probing.
-//
-// Per RFC 6762 §8.4, updating TXT records does NOT require re-probing since:
-// - The service instance name hasn't changed (no conflict possible)
-// - TXT records are metadata, not part of the unique service identity
-//
-// Process:
-//  1. Find service in registry
-//  2. Update TXT records
-//  3. Send announcement with updated TXT record (multicast to inform network)
-//
-// Parameters:
-//   - serviceID: Service identifier (InstanceName or InstanceName.ServiceType)
-//   - txtRecords: New TXT records to set
-//
-// Returns:
-//   - error: If service not found or update fails
-//
-// T106: Implement UpdateService without re-probing (US5 GREEN)
-func (r *Responder) UpdateService(serviceID string, txtRecords map[string]string) error {
-	// Lookup service
-	svc, found := r.GetService(serviceID)
-	if !found {
-		return fmt.Errorf("service %q not found", serviceID)
-	}
-
-	// Update TXT records in registry
-	// The registry stores internal/responder.Service, so we need to update it there
-	internalSvc, found := r.registry.Get(svc.InstanceName)
-	if !found {
-		return fmt.Errorf("internal error: service %q in GetService but not in registry", svc.InstanceName)
-	}
-
-	// Update TXT records
-	internalSvc.TXT = txtRecords
-
-	// Announce updated records per RFC 6762 §8.4
-	// Build updated record set
-	ipv4, err := getLocalIPv4()
-	if err != nil {
-		// Can't announce without IP, but registry is updated
-		return nil
-	}
-
-	serviceInfo := &records.ServiceInfo{
-		InstanceName: svc.InstanceName,
-		ServiceType:  svc.ServiceType,
-		Hostname:     r.hostname,
-		Port:         svc.Port,
-		IPv4Address:  ipv4,
-		TXTRecords:   txtRecords,
-	}
-	announcedRecords := records.BuildRecordSet(serviceInfo)
-
-	// Convert to message.ResourceRecord for BuildResponse
-	msgRecords := make([]*message.ResourceRecord, len(announcedRecords))
-	for i, rr := range announcedRecords {
-		msgRecords[i] = &message.ResourceRecord{
-			Name:       rr.Name,
-			Type:       rr.Type,
-			Class:      rr.Class,
-			TTL:        rr.TTL,
-			Data:       rr.Data,
-			CacheFlush: rr.CacheFlush,
-		}
-	}
-
-	responseBytes, err := message.BuildResponse(msgRecords)
-	if err != nil {
-		return nil // Registry updated, announcement failed - best effort
-	}
-
-	dest := &net.UDPAddr{
-		IP:   net.ParseIP("224.0.0.251"),
-		Port: 5353,
-	}
-	_ = r.transport.Send(r.ctx, responseBytes, dest) // nosemgrep: beacon-error-swallowing
-
-	return nil
-}
-
-// RegisterServiceWithoutProbing is a test hook that registers a service directly
-// in the registry without performing probing or announcing.
-//
-// This is intended ONLY for contract tests that need to test query handling
-// without the ~1.75s overhead of the full Register() flow.
-//
-// Parameters:
-//   - service: The service to register
-//
-// Returns:
-//   - error: validation or registry error
-func (r *Responder) RegisterServiceWithoutProbing(service *Service) error {
-	if service == nil {
-		return fmt.Errorf("service cannot be nil")
-	}
-	if err := service.Validate(); err != nil {
-		return err
-	}
-	internalService := &responder.Service{
-		InstanceName: service.InstanceName,
-		ServiceType:  service.ServiceType,
-		Port:         service.Port,
-		TXT:          service.TXTRecords,
-	}
-	return r.registry.Register(internalService)
-}
-
-// InjectConflictDuringProbing is a test hook to inject conflicts during probing.
-//
-// When enabled, the state machine will always report StateConflictDetected,
-// forcing the rename loop to trigger.
-//
-// T062: Test hook for max rename attempts testing
-func (r *Responder) InjectConflictDuringProbing(inject bool) {
-	r.injectConflict = inject
-}
-
-// InjectSimultaneousProbe is a test hook for injecting simultaneous probe scenarios.
-//
-// This method is currently a stub placeholder for future simultaneous probe testing
-// per RFC 6762 §8.2 tiebreaking. It will be implemented when detailed conflict
-// resolution testing is added.
-//
-// Parameters:
-//   - First parameter: Our probe packet (currently unused)
-//   - Second parameter: Incoming probe packet (currently unused)
-//
-// T062: Test hook infrastructure for conflict scenarios
-func (r *Responder) InjectSimultaneousProbe([]byte, []byte) {}
-
-// ResourceRecord is a type alias for records.ResourceRecord.
-//
-// This alias allows contract tests to reference ResourceRecord without importing
-// the internal records package directly, maintaining clean architecture boundaries.
-//
-// The underlying type contains DNS resource record fields:
-//   - Name: Domain name (e.g., "myservice._http._tcp.local")
-//   - Type: Record type (A, PTR, SRV, TXT per RFC 1035)
-//   - Class: Record class (IN for Internet)
-//   - TTL: Time-to-live in seconds
-//   - Data: Record-specific data (IP address, target name, etc.)
-//   - CacheFlush: Cache-flush bit per RFC 6762 §10.2
-//
-// US2 GREEN: Contract test support for validating resource records
-type ResourceRecord = records.ResourceRecord
-
-// runQueryHandler continuously receives and processes mDNS queries.
-//
-// RFC 6762 §6: Responders SHOULD respond to queries for services they have registered.
-//
-// Process:
-//  1. Receive query packet from transport
-//  2. Parse DNS message
-//  3. For each question, check if we have matching service
-//  4. Build response (PTR answer + SRV/TXT/A additional)
-//  5. Apply rate limiting per RFC 6762 §6.2
-//  6. Send response (unicast or multicast based on QU bit)
-//
-// T080: Query handler goroutine
-func (r *Responder) runQueryHandler() {
-	defer r.queryHandlerWg.Done()
-	for {
-		select {
-		case <-r.ctx.Done():
-			return
-		case <-r.queryHandlerDone:
-			return
-		default:
-			// Receive query with timeout
-			// 007-interface-specific-addressing T027: Extract interfaceIndex for RFC 6762 §15 compliance
-			// Task 2: Capture source address for subnet validation (RFC 6762 §6.4)
-			packet, srcAddr, interfaceIndex, err := r.transport.Receive(r.ctx)
-			if err != nil {
-				// Context cancelled or transport closed
-				select {
-				case <-r.ctx.Done():
-					return
-				case <-r.queryHandlerDone:
-					return
-				default:
-					// Other error - continue receiving
-					continue
-				}
-			}
-
-			// Handle query (T079)
-			// T028: Pass interfaceIndex to enable interface-specific addressing
-			// Task 2: Pass source address for subnet validation
-			_ = r.handleQuery(packet, srcAddr, interfaceIndex)
-		}
-	}
-}
-
-// validateSourceAddress validates that the query source is on the same subnet as the interface.
-//
-// RFC 6762 §6.4: "When a Multicast DNS responder receives a query, it MUST only respond
-// if the source address of the query is on the same subnet as the interface on which
-// the query was received."
-//
-// Parameters:
-//   - srcAddr: Source address of the query
-//   - interfaceIndex: OS interface index that received the query
-//
-// Returns:
-//   - bool: true if source is on same subnet, false otherwise
-//
-// Task 2: Source address validation
-func validateSourceAddress(srcAddr net.Addr, interfaceIndex int) bool {
-	// If interface index is unknown (0), skip validation (graceful degradation)
-	if interfaceIndex == 0 {
-		return true
-	}
-
-	// Extract IP from source address
-	udpAddr, ok := srcAddr.(*net.UDPAddr)
-	if !ok {
-		return false
-	}
-	srcIP := udpAddr.IP.To4()
-	if srcIP == nil {
-		return false // Not IPv4
-	}
-
-	// Get interface by index
-	iface, err := net.InterfaceByIndex(interfaceIndex)
-	if err != nil {
-		return false
-	}
-
-	// Get interface addresses
-	addrs, err := iface.Addrs()
-	if err != nil {
-		return false
-	}
-
-	// Check if source IP is on same subnet as any interface address
-	for _, addr := range addrs {
-		ipnet, ok := addr.(*net.IPNet)
-		if !ok {
-			continue
-		}
-
-		// Check if source IP is in this subnet
-		if ipnet.Contains(srcIP) {
-			return true
-		}
-	}
-
-	// Source IP not on same subnet
-	return false
-}
-
-// handleQuery processes a single mDNS query and sends response.
-//
-// RFC 6762 §6: "When a Multicast DNS responder receives a query, it must determine
-// whether the query is requesting information for which this responder is authoritative."
-//
-// RFC 6762 §6.4: "When a Multicast DNS responder receives a query, it MUST only respond
-// if the source address of the query is on the same subnet as the interface on which
-// the query was received."
-//
-// RFC 6762 §15: Responses MUST include only addresses valid on the receiving interface,
-// and MUST NOT include addresses from other interfaces.
-//
-// Process:
-//  1. Parse query message
-//  2. Validate source address (RFC 6762 §6.4)
-//  3. Extract questions
-//  4. Check if we have matching registered services
-//  5. Build response using ResponseBuilder with interface-specific IP (T029)
-//  6. Apply QU bit logic (unicast vs multicast)
-//  7. Apply rate limiting (RFC 6762 §6.2)
-//  8. Send response
-//
-// Parameters:
-//   - packet: DNS query in wire format
-//   - srcAddr: Source address of the query
-//   - interfaceIndex: OS interface index that received the query (0 = unknown)
-//
-// Returns:
-//   - error: parse error or send error (logged, not propagated)
-//
-// T079: Implement handleQuery()
-// T029: Added interfaceIndex parameter for interface-specific addressing
-// Task 2: Added srcAddr parameter for source address validation
-func (r *Responder) handleQuery(packet []byte, srcAddr net.Addr, interfaceIndex int) error {
-	// Task 2: RFC 6762 §6.4 - Validate source address is on same subnet
-	if !validateSourceAddress(srcAddr, interfaceIndex) {
-		// Source not on same subnet - ignore query per RFC 6762 §6.4
-		return nil
-	}
-
-	// Import message parser
-	msg, err := parseMessage(packet)
-	if err != nil {
-		// Malformed query - ignore per RFC 6762 §6
-		return err
-	}
-
-	// Ignore responses (QR=1)
-	if msg.Header.IsResponse() {
-		return nil
-	}
-
-	// DNS-SD meta-query name per RFC 6763 §9
-	const serviceEnumerationName = "_services._dns-sd._udp.local"
-
-	// Process each question
-	for _, question := range msg.Questions {
-		// RFC 6763 §9: Service Type Enumeration
-		// A PTR query for "_services._dns-sd._udp.local" returns all unique service types.
-		if question.QTYPE == uint16(protocol.RecordTypePTR) && question.QNAME == serviceEnumerationName {
-			serviceTypes := r.registry.ListServiceTypes()
-			if len(serviceTypes) == 0 {
-				continue // No services registered, no response needed
-			}
-
-			// Build PTR records: one for each unique service type
-			ptrRecords := make([]*message.ResourceRecord, 0, len(serviceTypes))
-			for _, svcType := range serviceTypes {
-				// RDATA for PTR record is the encoded service type name
-				encodedTarget, encErr := message.EncodeName(svcType)
-				if encErr != nil {
-					continue // Skip types that cannot be encoded
-				}
-				ptrRecords = append(ptrRecords, &message.ResourceRecord{
-					Name:       serviceEnumerationName,
-					Type:       protocol.RecordTypePTR,
-					Class:      protocol.ClassIN,
-					TTL:        protocol.TTLHostname, // 4500s per RFC 6762 §10
-					Data:       encodedTarget,
-					CacheFlush: false, // PTR is a shared record
-				})
-			}
-
-			if len(ptrRecords) == 0 {
-				continue
-			}
-
-			// Build DNS response message
-			responseMsg, buildErr := message.BuildResponse(ptrRecords)
-			if buildErr != nil {
-				continue
-			}
-
-			// Determine destination (unicast vs multicast based on QU bit)
-			quBit := (question.QCLASS & 0x8000) != 0
-			var dest net.Addr
-			if quBit {
-				dest = srcAddr
-			}
-			// nil dest = multicast to 224.0.0.251:5353
-
-			_ = r.transport.Send(r.ctx, responseMsg, dest)
-			continue
-		}
-
-		// Get all registered services
-		services := r.registry.List()
-
-		var matchedService *responder.Service
-		for _, instanceName := range services {
-			service, found := r.registry.Get(instanceName)
-			if !found {
-				continue
-			}
-
-			switch question.QTYPE {
-			case uint16(protocol.RecordTypePTR):
-				// PTR: match by service type (e.g., "_http._tcp.local")
-				if service.ServiceType == question.QNAME {
-					matchedService = service
-				}
-			case uint16(protocol.RecordTypeSRV), uint16(protocol.RecordTypeTXT):
-				// SRV/TXT: match by full instance name (e.g., "My Printer._http._tcp.local")
-				fullName := service.InstanceName + "." + service.ServiceType
-				if fullName == question.QNAME {
-					matchedService = service
-				}
-			case uint16(protocol.RecordTypeA):
-				// A: match by hostname (e.g., "myhost.local")
-				if r.hostname == question.QNAME {
-					matchedService = service
-				}
-			}
-
-			if matchedService != nil {
-				break
-			}
-		}
-
-		if matchedService == nil {
-			continue
-		}
-
-		// We have a match! Build response with interface-specific addressing
-		//
-		// RFC 6762 §15 "Responding to Address Queries":
-		// "When a Multicast DNS responder sends a Multicast DNS response message
-		// containing its own address records in response to a query received on
-		// a particular interface, it MUST include only addresses that are valid
-		// on that interface, and MUST NOT include addresses configured on other
-		// interfaces."
-		//
-		// T036: Inline comment citing RFC 6762 §15
-		var ipv4 []byte
-		var ipErr error
-
-		// T030: Graceful fallback when interface index unavailable (interfaceIndex=0)
-		// This happens when control messages aren't supported or platform doesn't provide IP_PKTINFO
-		if interfaceIndex == 0 {
-			// Degraded mode: Use default interface IP (legacy behavior)
-			// TODO T032: Add debug logging when F-6 (Logging & Observability) is implemented
-			ipv4, ipErr = getLocalIPv4()
-		} else {
-			// RFC 6762 §15 compliance: Use ONLY the IP from the receiving interface
-			ipv4, ipErr = getIPv4ForInterface(interfaceIndex)
-		}
-
-		if ipErr != nil {
-			// T031: If interface-specific IP lookup fails, skip response for this query
-			// This is correct behavior per RFC 6762 §15: Better to not respond than
-			// to respond with an incorrect (wrong interface) IP address
-			// TODO T032: Add error logging when F-6 is implemented
-			// Common failure causes: interface went down, no IPv4 configured, invalid index
-			continue
-		}
-
-		serviceWithIP := &responder.ServiceWithIP{
-			InstanceName: matchedService.InstanceName,
-			ServiceType:  matchedService.ServiceType,
-			Domain:       "local",
-			Port:         matchedService.Port,
-			IPv4Address:  ipv4,
-			TXTRecords:   matchedService.TXT, // internal.Service uses TXT field
-			Hostname:     r.hostname,
-		}
-
-		// Build response (T076)
-		response, err := r.responseBuilder.BuildResponse(serviceWithIP, msg)
-		if err != nil {
-			continue
-		}
-
-		// Per-source-IP rate limiting (FR-026, RFC 6762 §6.2)
-		if r.rateLimiter != nil && srcAddr != nil {
-			srcIP := srcAddr.String()
-			if udpAddr, ok := srcAddr.(*net.UDPAddr); ok {
-				srcIP = udpAddr.IP.String()
-			}
-			if !r.rateLimiter.Allow(srcIP) {
-				continue // Rate-limited, skip response
-			}
-		}
-
-		// RFC 6762 §5.4: Check QU bit (bit 15 of QCLASS) to determine unicast vs multicast
-		// Task 4: QU bit handling
-		quBit := (question.QCLASS & 0x8000) != 0
-
-		var dest net.Addr
-		if quBit {
-			// RFC 6762 §5.4: QU bit set → send unicast response to querier
-			dest = srcAddr
-		} else {
-			// RFC 6762 §5.4: QU bit clear → send multicast response
-			dest = nil // nil = multicast to 224.0.0.251:5353
-		}
-
-		// Send response
-		responsePacket := buildResponsePacket(response)
-		_ = r.transport.Send(r.ctx, responsePacket, dest)
-	}
-
-	return nil
-}
-
-// parseMessage is a wrapper around message.ParseMessage for easier imports.
-func parseMessage(packet []byte) (*message.DNSMessage, error) {
-	return message.ParseMessage(packet)
-}
-
-// buildResponsePacket serializes a DNSMessage to wire format using message.SerializeMessage.
-//
-// RFC 1035 §4.1: Converts the complete DNSMessage struct (header, questions,
-// answers, authority, additional sections) into wire-format bytes.
-func buildResponsePacket(msg *message.DNSMessage) []byte {
-	data, err := message.SerializeMessage(msg)
-	if err != nil {
-		// Serialization failed - return minimal valid DNS response header
-		// so the responder doesn't crash on unexpected serialization errors
-		return []byte{
-			0x00, 0x00, // ID
-			0x84, 0x00, // Flags (QR=1, AA=1)
-			0x00, 0x00, // QDCount
-			0x00, 0x00, // ANCount
-			0x00, 0x00, // NSCount
-			0x00, 0x00, // ARCount
-		}
-	}
-	return data
 }

--- a/responder/responder_test.go
+++ b/responder/responder_test.go
@@ -139,7 +139,7 @@ func TestResponder_Register_Validation(t *testing.T) {
 				Port:         8080,
 			},
 			wantErr:     true,
-			errContains: "invalid service type format",
+			errContains: "begin with an underscore",
 		},
 		{
 			name: "invalid - port 0",

--- a/responder/service.go
+++ b/responder/service.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 )
 
 // Service represents an mDNS service to be registered per RFC 6763.
@@ -191,12 +192,54 @@ func validateServiceType(serviceType string) error {
 		return fmt.Errorf("service type cannot be empty")
 	}
 
-	// Use regex for robust validation
+	// serviceTypeRegex is the single source of truth for accept/reject. When it
+	// rejects, describeInvalidServiceType produces a specific, RFC-cited reason
+	// (see issue #31) — but it never changes WHAT is accepted or rejected.
 	if !serviceTypeRegex.MatchString(serviceType) {
-		return fmt.Errorf("invalid service type format (must be _service._proto.local, e.g., \"_http._tcp.local\")")
+		return describeInvalidServiceType(serviceType)
 	}
 
 	return nil
+}
+
+// describeInvalidServiceType returns a specific error explaining why
+// serviceType failed serviceTypeRegex (`^_[a-z0-9-]+\._(tcp|udp)\.local$`).
+//
+// It is only called after the regex has already rejected the input, so it never
+// returns nil. The goal (issue #31) is to name the precise problem — especially
+// a disallowed character such as an embedded underscore — and cite RFC 6763 §7,
+// which permits only letters, digits, and hyphens in a Service Name.
+func describeInvalidServiceType(serviceType string) error {
+	const example = `_http._tcp.local`
+
+	labels := strings.Split(serviceType, ".")
+	if len(labels) != 3 || labels[2] != "local" {
+		return fmt.Errorf("invalid service type %q: must have the form _service._proto.local and end in \".local\" (e.g. %q)", serviceType, example)
+	}
+
+	name, proto := labels[0], labels[1]
+
+	// Service-name label: leading underscore + one-or-more [a-z0-9-] per RFC 6763 §7.
+	if name == "" || name[0] != '_' {
+		return fmt.Errorf("invalid service type %q: the service name must begin with an underscore (e.g. %q)", serviceType, example)
+	}
+	if len(name) == 1 {
+		return fmt.Errorf("invalid service type %q: the service name after the underscore is empty (e.g. %q)", serviceType, example)
+	}
+	for i := 1; i < len(name); i++ {
+		c := name[i]
+		if !((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-') {
+			return fmt.Errorf("invalid service type %q: character %q at position %d is not allowed; RFC 6763 §7 permits only lowercase letters, digits, and hyphens in service names (use \"-\" instead of \"_\")", serviceType, string(c), i)
+		}
+	}
+
+	// Service name is well-formed, so the protocol label must be at fault.
+	if proto != "_tcp" && proto != "_udp" {
+		return fmt.Errorf("invalid service type %q: protocol label %q must be \"_tcp\" or \"_udp\" (e.g. %q)", serviceType, proto, example)
+	}
+
+	// Fallback: regex rejected for a reason not isolated above.
+	return fmt.Errorf("invalid service type %q: must have the form _service._proto.local (e.g. %q)", serviceType, example)
 }
 
 // validateTXTRecordsSize validates that TXT records don't exceed RFC limits.

--- a/responder/service_test.go
+++ b/responder/service_test.go
@@ -37,13 +37,13 @@ func TestService_Validate_ServiceType(t *testing.T) {
 			name:        "invalid - missing leading underscore",
 			serviceType: "http._tcp.local",
 			wantErr:     true,
-			errContains: "invalid service type format",
+			errContains: "begin with an underscore",
 		},
 		{
 			name:        "invalid - missing protocol underscore",
 			serviceType: "_http.tcp.local",
 			wantErr:     true,
-			errContains: "invalid service type format",
+			errContains: "protocol label",
 		},
 		{
 			name:        "invalid - empty string",
@@ -55,13 +55,38 @@ func TestService_Validate_ServiceType(t *testing.T) {
 			name:        "invalid - invalid protocol (must be _tcp or _udp)",
 			serviceType: "_http._sctp.local",
 			wantErr:     true,
-			errContains: "invalid service type format",
+			errContains: "protocol label",
 		},
 		{
 			name:        "invalid - missing domain",
 			serviceType: "_http._tcp",
 			wantErr:     true,
-			errContains: "invalid service type format",
+			errContains: ".local",
+		},
+		// Issue #31: clearer diagnostics for invalid characters in the service
+		// name. RFC 6763 §7 permits only letters, digits, and hyphens.
+		{
+			name:        "invalid - embedded underscore names offending char + RFC",
+			serviceType: "_my_service._tcp.local",
+			wantErr:     true,
+			errContains: "RFC 6763 §7",
+		},
+		{
+			name:        "invalid - embedded underscore reports the underscore char",
+			serviceType: "_my_service._tcp.local",
+			wantErr:     true,
+			errContains: `character "_"`,
+		},
+		{
+			name:        "invalid - uppercase letter is rejected with RFC cite",
+			serviceType: "_HTTP._tcp.local",
+			wantErr:     true,
+			errContains: "RFC 6763 §7",
+		},
+		{
+			name:        "valid - hyphen in service name still accepted",
+			serviceType: "_my-service._tcp.local",
+			wantErr:     false,
 		},
 	}
 

--- a/responder/testhooks.go
+++ b/responder/testhooks.go
@@ -1,0 +1,138 @@
+package responder
+
+import "fmt"
+
+// This file contains test-only hooks on the Responder.
+//
+// They exist solely to enable black-box contract tests (in package
+// tests/contract and responder's own *_test.go) to observe and inject protocol
+// behavior — captured probe/announce messages, probe/announce callbacks, fast
+// registration without the ~1.75s probing delay, and conflict injection — without
+// reaching into internal packages or weakening the F-2 layer boundary.
+//
+// They are NOT part of the responder's runtime behavior. If the contract tests
+// are ever moved white-box (into package responder with an export_test.go), this
+// surface can be removed from the public API entirely. See B2 in the refactor
+// punch-list for that deliberate, deferred decision.
+
+// OnProbe sets a callback to be called when a probe is sent.
+//
+// US2 GREEN: Contract test support for RFC 6762 §8.1 validation
+func (r *Responder) OnProbe(callback func()) {
+	// Store callback for future machines
+	r.onProbeCallback = callback
+
+	// Also apply to current machine if it exists
+	if r.lastMachine != nil {
+		prober := r.lastMachine.GetProber()
+		if prober != nil {
+			prober.SetOnSendQuery(callback)
+		}
+	}
+}
+
+// OnAnnounce sets a callback to be called when an announcement is sent.
+//
+// US2 GREEN: Contract test support for RFC 6762 §8.3 validation
+func (r *Responder) OnAnnounce(callback func()) {
+	// Store callback for future machines
+	r.onAnnounceCallback = callback
+
+	// Also apply to current machine if it exists
+	if r.lastMachine != nil {
+		announcer := r.lastMachine.GetAnnouncer()
+		if announcer != nil {
+			announcer.SetOnSendAnnouncement(callback)
+		}
+	}
+}
+
+// GetLastProbeMessage returns the last sent probe message.
+//
+// US2 GREEN: Contract test support for RFC 6762 §8.1 validation
+func (r *Responder) GetLastProbeMessage() []byte {
+	if r.lastMachine != nil {
+		prober := r.lastMachine.GetProber()
+		if prober != nil {
+			return prober.GetLastProbeMessage()
+		}
+	}
+	return nil
+}
+
+// GetLastAnnounceMessage returns the last sent announcement message.
+//
+// US2 GREEN: Contract test support for RFC 6762 §8.3 validation
+func (r *Responder) GetLastAnnounceMessage() []byte {
+	if r.lastMachine != nil {
+		announcer := r.lastMachine.GetAnnouncer()
+		if announcer != nil {
+			return announcer.GetLastAnnounceMessage()
+		}
+	}
+	return nil
+}
+
+// GetLastAnnouncedRecords returns the last announced record set.
+//
+// US2 GREEN: Contract test support for RFC 6762 §8.3 and RFC 6763 §6 validation
+func (r *Responder) GetLastAnnouncedRecords() []*ResourceRecord {
+	return r.lastAnnouncedRecords
+}
+
+// GetLastAnnounceDest returns the last announcement destination address.
+//
+// US2 GREEN: Contract test support for RFC 6762 §5 multicast address validation
+func (r *Responder) GetLastAnnounceDest() string {
+	if r.lastMachine != nil {
+		announcer := r.lastMachine.GetAnnouncer()
+		if announcer != nil {
+			return announcer.GetLastDestAddr()
+		}
+	}
+	return ""
+}
+
+// RegisterServiceWithoutProbing is a test hook that registers a service directly
+// in the registry without performing probing or announcing.
+//
+// This is intended ONLY for contract tests that need to test query handling
+// without the ~1.75s overhead of the full Register() flow.
+//
+// Parameters:
+//   - service: The service to register
+//
+// Returns:
+//   - error: validation or registry error
+func (r *Responder) RegisterServiceWithoutProbing(service *Service) error {
+	if service == nil {
+		return fmt.Errorf("service cannot be nil")
+	}
+	if err := service.Validate(); err != nil {
+		return err
+	}
+	return r.registry.Register(toInternalService(service))
+}
+
+// InjectConflictDuringProbing is a test hook to inject conflicts during probing.
+//
+// When enabled, the state machine will always report StateConflictDetected,
+// forcing the rename loop to trigger.
+//
+// T062: Test hook for max rename attempts testing
+func (r *Responder) InjectConflictDuringProbing(inject bool) {
+	r.injectConflict = inject
+}
+
+// InjectSimultaneousProbe is a test hook for injecting simultaneous probe scenarios.
+//
+// This method is currently a stub placeholder for future simultaneous probe testing
+// per RFC 6762 §8.2 tiebreaking. It will be implemented when detailed conflict
+// resolution testing is added.
+//
+// Parameters:
+//   - First parameter: Our probe packet (currently unused)
+//   - Second parameter: Incoming probe packet (currently unused)
+//
+// T062: Test hook infrastructure for conflict scenarios
+func (r *Responder) InjectSimultaneousProbe([]byte, []byte) {}

--- a/tests/contract/rfc6763_service_enumeration_test.go
+++ b/tests/contract/rfc6763_service_enumeration_test.go
@@ -78,7 +78,7 @@ func TestRFC6763_ServiceEnumeration_MetaQuery(t *testing.T) {
 		t.Fatalf("responder.New() error = %v, want nil", err)
 	}
 	defer func() {
-		cancel()              // Cancel context first to unblock Receive()
+		cancel() // Cancel context first to unblock Receive()
 		_ = r.Close()
 	}()
 

--- a/tests/fuzz/name_fuzz_test.go
+++ b/tests/fuzz/name_fuzz_test.go
@@ -1,0 +1,79 @@
+// Package fuzz provides fuzz testing for DNS message handling.
+//
+// This file fuzzes DNS name encoding/parsing (RFC 1035 §3.1, RFC 6763 §4.1.2)
+// for two properties:
+//   - ParseName MUST NOT panic on arbitrary bytes (NFR-003).
+//   - Encode→Parse→Encode is idempotent at the wire-byte level for any name
+//     that EncodeName accepts (a name that encodes must parse back to a name
+//     that re-encodes to the identical bytes).
+package fuzz
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/joshuafuller/beacon/internal/message"
+)
+
+// FuzzNameRoundTrip verifies that names accepted by EncodeName survive an
+// encode→parse→encode cycle without loss, and that ParseName never panics on
+// the resulting bytes.
+//
+// Comparing the wire bytes (rather than the strings) avoids baking in any
+// assumption about case-folding or trailing-dot normalization; it asserts the
+// codec is self-consistent, which is the property that matters on the wire.
+//
+// Run with: go test -fuzz=FuzzNameRoundTrip -fuzztime=20s ./tests/fuzz/
+func FuzzNameRoundTrip(f *testing.F) {
+	// Seed corpus: representative valid mDNS / DNS-SD names.
+	for _, s := range []string{
+		"test.local",
+		"_http._tcp.local",
+		"My Printer._http._tcp.local",
+		"a.b.c.d.local",
+		"x.local",
+		"_services._dns-sd._udp.local",
+		"my-device.local",
+	} {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, name string) {
+		enc1, err := message.EncodeName(name)
+		if err != nil {
+			// Input is not a name EncodeName accepts; nothing to round-trip.
+			return
+		}
+
+		// Property 1: ParseName must not panic and must succeed on output that
+		// EncodeName produced.
+		parsed, _, err := message.ParseName(enc1, 0)
+		if err != nil {
+			t.Fatalf("EncodeName accepted %q but ParseName rejected its output (% x): %v", name, enc1, err)
+		}
+
+		// Property 2: re-encoding the parsed name yields identical wire bytes.
+		enc2, err := message.EncodeName(parsed)
+		if err != nil {
+			t.Fatalf("round-trip name %q (from %q) failed to re-encode: %v", parsed, name, err)
+		}
+		if !bytes.Equal(enc1, enc2) {
+			t.Fatalf("round-trip mismatch:\n  input:  %q -> % x\n  parsed: %q -> % x", name, enc1, parsed, enc2)
+		}
+	})
+}
+
+// FuzzParseNameRaw verifies ParseName never panics on arbitrary byte buffers
+// and arbitrary (possibly out-of-range) offsets per NFR-003.
+//
+// Run with: go test -fuzz=FuzzParseNameRaw -fuzztime=20s ./tests/fuzz/
+func FuzzParseNameRaw(f *testing.F) {
+	f.Add([]byte{0x04, 't', 'e', 's', 't', 0x00}, 0)
+	f.Add([]byte{0xc0, 0x00}, 0)             // compression pointer to self
+	f.Add([]byte{0x05, 'l', 'o', 'c', 'a'}, 0) // length exceeds remaining bytes
+
+	f.Fuzz(func(t *testing.T, buf []byte, offset int) {
+		// Must not panic regardless of buffer contents or offset; errors are fine.
+		_, _, _ = message.ParseName(buf, offset)
+	})
+}

--- a/tests/fuzz/name_fuzz_test.go
+++ b/tests/fuzz/name_fuzz_test.go
@@ -69,7 +69,7 @@ func FuzzNameRoundTrip(f *testing.F) {
 // Run with: go test -fuzz=FuzzParseNameRaw -fuzztime=20s ./tests/fuzz/
 func FuzzParseNameRaw(f *testing.F) {
 	f.Add([]byte{0x04, 't', 'e', 's', 't', 0x00}, 0)
-	f.Add([]byte{0xc0, 0x00}, 0)             // compression pointer to self
+	f.Add([]byte{0xc0, 0x00}, 0)               // compression pointer to self
 	f.Add([]byte{0x05, 'l', 'o', 'c', 'a'}, 0) // length exceeds remaining bytes
 
 	f.Fuzz(func(t *testing.T, buf []byte, offset int) {

--- a/tests/fuzz/service_type_fuzz_test.go
+++ b/tests/fuzz/service_type_fuzz_test.go
@@ -1,0 +1,90 @@
+// Package fuzz provides fuzz testing for DNS-SD service-type validation.
+//
+// This file hammers responder service-type validation (the serviceTypeRegex in
+// responder/service.go, RFC 6763 §7) with a *differential* oracle: an
+// independent, regex-free reimplementation of the regex's intended grammar is
+// compared against the real validator for millions of inputs. Any divergence
+// indicates a validator bug (bad anchoring, newline injection, stray character
+// class, etc.) — the failure modes that are easy to miss by eyeballing a regex.
+package fuzz
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/joshuafuller/beacon/responder"
+)
+
+// oracleValidServiceType is an independent reference for the grammar the
+// responder's serviceTypeRegex (`^_[a-z0-9-]+\._(tcp|udp)\.local$`) is meant to
+// accept, implemented WITHOUT a regular expression so it can act as a check on
+// the regex itself:
+//
+//	_<name>._<tcp|udp>.local
+//	where <name> is one or more of [a-z0-9-]
+//
+// Exactly three dot-separated labels, ASCII only, no trailing dot, no newlines.
+func oracleValidServiceType(s string) bool {
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	name, proto, tld := parts[0], parts[1], parts[2]
+
+	if tld != "local" {
+		return false
+	}
+	if proto != "_tcp" && proto != "_udp" {
+		return false
+	}
+	// name = "_" followed by one-or-more [a-z0-9-]
+	if len(name) < 2 || name[0] != '_' {
+		return false
+	}
+	for i := 1; i < len(name); i++ {
+		c := name[i]
+		ok := (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-'
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// FuzzServiceTypeValidation runs the differential oracle against the real
+// validator. InstanceName and Port are fixed to valid values so that
+// Service.Validate() returns nil iff the SERVICE TYPE is the only thing that
+// could be wrong — isolating the regex under test.
+//
+// Run with: go test -fuzz=FuzzServiceTypeValidation -fuzztime=30s ./tests/fuzz/
+func FuzzServiceTypeValidation(f *testing.F) {
+	for _, s := range []string{
+		"_http._tcp.local",
+		"_my-service._tcp.local",
+		"_my_service._tcp.local", // embedded underscore — rejected (issue #31)
+		"_ipp._udp.local",
+		"_http._tcp.local.",      // trailing dot
+		"_http._tcp.local\n",     // trailing newline (anchoring probe)
+		"_HTTP._tcp.local",       // uppercase
+		"_http._sctp.local",      // wrong proto
+		"_http._tcp.example.com", // wrong tld
+		"_._tcp.local",           // empty name
+		"",
+	} {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, serviceType string) {
+		svc := &responder.Service{
+			InstanceName: "fuzz",
+			ServiceType:  serviceType,
+			Port:         8080,
+		}
+		// Must never panic on any input.
+		got := svc.Validate() == nil
+		want := oracleValidServiceType(serviceType)
+		if got != want {
+			t.Fatalf("service-type validation disagrees with oracle for %q: Validate()==nil is %v, oracle is %v", serviceType, got, want)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Cuts **v1.3.0**. The headline: the responder now actually answers queries on the wire (v1.2.2 shipped a stubbed `buildResponsePacket` returning an empty packet). Plus querier correctness fixes, an internal refactor, and extensive test hardening. **No public API breakage.**

## Fixes
- **Querier `WithTimeout` honored** for deadline-less contexts (was: `Query(context.Background(), …)` hung forever).
- **`DiscoverServices` resolves SRV hostname/port** — `AsSRV()` asserted the wrong named type and always returned `nil`.
- Actionable service-type validation errors (issue #31): name the offending char + cite RFC 6763 §7.

## Added
- `Response.Additionals` + `DiscoverServices` single-round-trip resolution (RFC 6763 §12), with query fallback.

## Changed (internal, no API impact)
- `responder` god-object split into cohesive files.
- Injectable clock in rate limiter + record TTL/multicast trackers.
- Fuzz + mutation-test hardening (protocol 100%, security/records near max killable efficacy).

## Verification
- Full suite + `-race` green; `go vet` clean; gofmt clean.
- Two independent code reviews (refactor + additionals) confirmed behavior-preserving / non-breaking.

## Known limitation
- Compressed SRV/PTR targets (Avahi/Bonjour) not yet resolved from RDATA → cross-responder SRV resolution limited; beacon↔beacon unaffected. Follow-up tracked.

Relates to issue #31.