### PR TITLE
fix: resolve compressed PTR/SRV target names in RDATA (cross-responder discovery)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Beacon mDNS library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-06-20
+
+### Fixed
+- **Compressed PTR/SRV target names are now resolved (FR-012).** DNS responders
+  such as Avahi and Bonjour compress the target names inside SRV/PTR RDATA with
+  back-pointers into the message. The parser previously parsed each RDATA slice
+  in isolation and could not follow those pointers, so cross-responder SRV/PTR
+  resolution (e.g. `DiscoverServices` host/port against Avahi/Bonjour) silently
+  failed. RDATA is now parsed against the full message. Beacon-to-beacon
+  discovery was unaffected and remains so. No public API breakage.
+
 ## [1.3.0] - 2026-06-20
 
 First release in which the responder actually answers queries on the wire. v1.2.2

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -225,6 +225,12 @@ type Answer struct {
 	//
 	// FR-012: System MUST decompress DNS names in RDATA (PTR, SRV target)
 	RDATA []byte
+
+	// RDATAOffset is the byte offset of RDATA within the full message it was
+	// parsed from. It lets ParseRDATAInMessage resolve DNS name-compression
+	// pointers in PTR/SRV targets against the whole message (FR-012); it is 0
+	// for Answers not produced by ParseMessage.
+	RDATAOffset int
 }
 
 // DNSMessage represents a complete DNS message per RFC 1035 §4.1.

--- a/internal/message/parser.go
+++ b/internal/message/parser.go
@@ -254,12 +254,13 @@ func ParseAnswer(msg []byte, offset int) (Answer, int, error) {
 	copy(rdata, msg[newOffset:newOffset+int(rdlength)])
 
 	answer := Answer{
-		NAME:     name,
-		TYPE:     rtype,
-		CLASS:    class,
-		TTL:      ttl,
-		RDLENGTH: rdlength,
-		RDATA:    rdata,
+		NAME:        name,
+		TYPE:        rtype,
+		CLASS:       class,
+		TTL:         ttl,
+		RDLENGTH:    rdlength,
+		RDATA:       rdata,
+		RDATAOffset: newOffset, // RDATA begins here within msg (after the 10 fixed bytes)
 	}
 
 	return answer, newOffset + int(rdlength), nil
@@ -284,19 +285,49 @@ func ParseAnswer(msg []byte, offset int) (Answer, int, error) {
 //   - parsed: Type-specific parsed data (net.IP, string, []string, or SRVData)
 //   - error: WireFormatError if RDATA is malformed
 func ParseRDATA(recordType uint16, rdata []byte) (interface{}, error) {
+	// No surrounding-message context: treat rdata as a self-contained buffer.
+	// DNS name-compression pointers inside PTR/SRV targets reference earlier
+	// bytes of the full message and therefore CANNOT be resolved here — callers
+	// that have the full message should use ParseRDATAInMessage so that
+	// responders which compress (e.g. Avahi/Bonjour) interoperate (FR-012).
+	return ParseRDATAInMessage(recordType, rdata, 0, len(rdata))
+}
+
+// ParseRDATAInMessage parses the type-specific RDATA located at rdataStart (of
+// length rdlength) within the full message msg. Unlike ParseRDATA, it resolves
+// DNS name-compression pointers in PTR and SRV targets against msg, which is
+// required to interoperate with responders that compress those names (FR-012).
+//
+// For A and TXT records (no embedded names) it is equivalent to ParseRDATA.
+//
+// Parameters:
+//   - recordType: The DNS record type (A, PTR, SRV, TXT)
+//   - msg: The complete DNS message (for compression-pointer resolution)
+//   - rdataStart: Byte offset of RDATA within msg
+//   - rdlength: Length of RDATA in bytes
+func ParseRDATAInMessage(recordType uint16, msg []byte, rdataStart, rdlength int) (interface{}, error) {
+	if rdataStart < 0 || rdlength < 0 || rdataStart+rdlength > len(msg) {
+		return nil, &errors.WireFormatError{
+			Operation: "parse RDATA",
+			Offset:    rdataStart,
+			Message:   fmt.Sprintf("RDATA out of bounds: start=%d len=%d msg=%d", rdataStart, rdlength, len(msg)),
+		}
+	}
+	rdata := msg[rdataStart : rdataStart+rdlength]
+
 	switch recordType {
 	case 1: // A record: IPv4 address (4 bytes)
 		if len(rdata) != 4 {
 			return nil, &errors.WireFormatError{
 				Operation: "parse A record",
-				Offset:    0,
+				Offset:    rdataStart,
 				Message:   fmt.Sprintf("invalid A record length: %d bytes, expected 4", len(rdata)),
 			}
 		}
 		return net.IPv4(rdata[0], rdata[1], rdata[2], rdata[3]), nil
 
-	case 12: // PTR record: Domain name
-		name, _, err := ParseName(rdata, 0)
+	case 12: // PTR record: Domain name (may be compressed against msg)
+		name, _, err := ParseName(msg, rdataStart)
 		if err != nil {
 			return nil, err
 		}
@@ -327,11 +358,11 @@ func ParseRDATA(recordType uint16, rdata []byte) (interface{}, error) {
 		}
 		return strings, nil
 
-	case 33: // SRV record: Priority, Weight, Port, Target
+	case 33: // SRV record: Priority, Weight, Port, Target (target may be compressed)
 		if len(rdata) < 6 {
 			return nil, &errors.WireFormatError{
 				Operation: "parse SRV record",
-				Offset:    0,
+				Offset:    rdataStart,
 				Message:   fmt.Sprintf("truncated SRV record: %d bytes, expected at least 6", len(rdata)),
 			}
 		}
@@ -340,8 +371,9 @@ func ParseRDATA(recordType uint16, rdata []byte) (interface{}, error) {
 		weight := binary.BigEndian.Uint16(rdata[2:4])
 		port := binary.BigEndian.Uint16(rdata[4:6])
 
-		// Target is a domain name starting at offset 6
-		target, _, err := ParseName(rdata, 6)
+		// Target is a domain name starting 6 bytes into RDATA; resolve against
+		// the full message so compression pointers work.
+		target, _, err := ParseName(msg, rdataStart+6)
 		if err != nil {
 			return nil, err
 		}
@@ -356,7 +388,7 @@ func ParseRDATA(recordType uint16, rdata []byte) (interface{}, error) {
 	default:
 		return nil, &errors.WireFormatError{
 			Operation: "parse RDATA",
-			Offset:    0,
+			Offset:    rdataStart,
 			Message:   fmt.Sprintf("unsupported record type: %d", recordType),
 		}
 	}

--- a/internal/message/parser_test.go
+++ b/internal/message/parser_test.go
@@ -578,3 +578,75 @@ func TestParseMessage_WithCompression(t *testing.T) {
 		t.Errorf("Answer NAME = %q, want %q (decompressed per RFC 1035 §4.1.4)", parsed.Answers[0].NAME, testLocalName)
 	}
 }
+
+// TestParseRDATAInMessage_CompressedSRVTarget proves the compression fix
+// (FR-012): an SRV target encoded with a DNS compression pointer (as Avahi and
+// Bonjour do) resolves correctly when parsed against the full message, whereas
+// the context-free ParseRDATA cannot follow the pointer out of the isolated
+// RDATA slice.
+func TestParseRDATAInMessage_CompressedSRVTarget(t *testing.T) {
+	// Build a synthetic message:
+	//   [0..11]  12-byte header (zeros)
+	//   [12..18] label sequence "local" + root: 05 'l' 'o' 'c' 'a' 'l' 00
+	//   [19..]   SRV RDATA: prio(0) weight(0) port(8080) "host" <ptr->12>
+	msg := make([]byte, 12)                                // header
+	msg = append(msg, 0x05, 'l', 'o', 'c', 'a', 'l', 0x00) // "local." at offset 12
+
+	rdataStart := len(msg) // 19
+	srv := []byte{
+		0x00, 0x00, // priority
+		0x00, 0x00, // weight
+		0x1f, 0x90, // port 8080
+		0x04, 'h', 'o', 's', 't', // "host"
+		0xC0, 0x0C, // compression pointer -> offset 12 ("local")
+	}
+	msg = append(msg, srv...)
+	rdlength := len(srv)
+
+	// New path: resolves the compressed target against the full message.
+	data, err := ParseRDATAInMessage(33, msg, rdataStart, rdlength)
+	if err != nil {
+		t.Fatalf("ParseRDATAInMessage(SRV) returned error: %v", err)
+	}
+	srvData, ok := data.(SRVData)
+	if !ok {
+		t.Fatalf("expected SRVData, got %T", data)
+	}
+	if srvData.Target != "host.local" {
+		t.Errorf("Target = %q, want %q (compression pointer must resolve)", srvData.Target, "host.local")
+	}
+	if srvData.Port != 8080 {
+		t.Errorf("Port = %d, want 8080", srvData.Port)
+	}
+
+	// Old path: parsing the isolated RDATA slice cannot follow the pointer
+	// (it references message bytes outside the slice) — documents the bug the
+	// new function fixes.
+	if _, err := ParseRDATA(33, srv); err == nil {
+		t.Errorf("ParseRDATA(SRV) on isolated compressed RDATA unexpectedly succeeded; expected failure (cannot resolve pointer)")
+	}
+}
+
+// TestParseRDATAInMessage_CompressedPTRTarget proves the same for PTR targets.
+func TestParseRDATAInMessage_CompressedPTRTarget(t *testing.T) {
+	msg := make([]byte, 12)                                                    // header
+	msg = append(msg, 0x05, '_', 'h', 't', 't', 'p', 0x04, '_', 't', 'c', 'p', // "_http._tcp"
+		0x05, 'l', 'o', 'c', 'a', 'l', 0x00) // "...local." starting at offset 12
+
+	rdataStart := len(msg)
+	// PTR target "Inst" + pointer to "_http._tcp.local" at offset 12.
+	ptr := []byte{0x04, 'I', 'n', 's', 't', 0xC0, 0x0C}
+	msg = append(msg, ptr...)
+
+	data, err := ParseRDATAInMessage(12, msg, rdataStart, len(ptr))
+	if err != nil {
+		t.Fatalf("ParseRDATAInMessage(PTR) returned error: %v", err)
+	}
+	name, ok := data.(string)
+	if !ok {
+		t.Fatalf("expected string, got %T", data)
+	}
+	if name != "Inst._http._tcp.local" {
+		t.Errorf("PTR target = %q, want %q (compression pointer must resolve)", name, "Inst._http._tcp.local")
+	}
+}

--- a/querier/querier.go
+++ b/querier/querier.go
@@ -469,8 +469,9 @@ func (q *Querier) collectResponses(ctx context.Context, _ string, queryType Reco
 					continue
 				}
 
-				// Parse type-specific RDATA
-				data, err := message.ParseRDATA(answer.TYPE, answer.RDATA)
+				// Parse type-specific RDATA against the full message so compressed
+				// PTR/SRV target names (used by Avahi/Bonjour) resolve.
+				data, err := message.ParseRDATAInMessage(answer.TYPE, responseMsg, answer.RDATAOffset, int(answer.RDLENGTH))
 				if err != nil {
 					// Malformed RDATA - skip this record per FR-011
 					continue
@@ -499,17 +500,10 @@ func (q *Querier) collectResponses(ctx context.Context, _ string, queryType Reco
 			// Retain Additional-section records (RFC 6763 §12). DNS-SD responders
 			// bundle SRV/TXT/A here so one PTR query resolves a whole instance;
 			// DiscoverServices consumes them to skip follow-up queries (issue #4).
-			//
-			// CAVEAT: ParseRDATA parses each RDATA slice in isolation, so names
-			// inside RDATA (SRV/PTR targets) that use DNS compression pointers
-			// (0xC0 back-references into the full message — common in Avahi/Bonjour
-			// responses) cannot be resolved and the record is skipped here; the
-			// query falls back to explicit lookups. Beacon's own responder does
-			// not compress, so beacon<->beacon discovery gets the single-round-trip
-			// path. Fixing cross-responder bundling needs ParseRDATA to take the
-			// full message + offset (tracked as a follow-up).
+			// Parsing against the full message resolves compressed SRV/PTR target
+			// names, so bundled additionals from Avahi/Bonjour resolve too.
 			for _, add := range parsedMsg.Additionals {
-				data, err := message.ParseRDATA(add.TYPE, add.RDATA)
+				data, err := message.ParseRDATAInMessage(add.TYPE, responseMsg, add.RDATAOffset, int(add.RDLENGTH))
 				if err != nil {
 					continue
 				}


### PR DESCRIPTION
## Summary
Closes the last interop gap from v1.3.0: SRV/PTR target names that use **DNS name compression** (0xC0 back-pointers — emitted by **Avahi/Bonjour**) could not be resolved because `ParseRDATA` parsed each RDATA slice in isolation. This was a documented-but-unmet requirement (FR-012).

## Change
- Add `message.ParseRDATAInMessage(recordType, msg, rdataStart, rdlength)` — resolves PTR/SRV target names against the full message. `ParseRDATA` delegates with `(rdata, 0, len(rdata))` → **behavior-identical** for the no-context path.
- `Answer` gains `RDATAOffset` (set by `ParseAnswer`).
- querier `collectResponses` parses Answers **and** Additionals with the context-aware function → bundled additionals from compressing responders now resolve (single-round-trip discovery works cross-responder).

## Tests (RED-first)
- `TestParseRDATAInMessage_CompressedSRVTarget` / `_CompressedPTRTarget`: new function resolves a compressed target; the isolated-slice `ParseRDATA` fails (documents the bug). A/TXT unchanged.

## Verification
- Full suite + `-race` green; `gofmt`/`vet` clean.
- Independent review: behavior-preserving, bounds-safe, pointer-loop-safe (ParseName rejects forward/looping pointers).

Backward-compatible bug fix → suitable for **v1.3.1**.