### PR TITLE
Fix golangci config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,9 +54,11 @@ linters:
 
     govet:
       enable-all: true  # Enable all optional go vet analyzers
+      disable:
+        - fieldalignment # Disabled due to number of affected structs
       settings:
         shadow:
-          strict: true
+          strict: false  # Set to false due to number of affected vars
 
     gocyclo:
       min-complexity: 15  # Allow moderate complexity for protocol parsing

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,15 +9,13 @@ run:
   timeout: 5m
   tests: true
   build-tags: []
-  skip-files: []
   modules-download-mode: readonly
 
 output:
   formats:
-    - format: colored-line-number
+    text:
       path: stdout
-  print-issued-lines: true
-  print-linter-name: true
+      colors: true
   show-stats: true
 
 linters:
@@ -72,47 +70,60 @@ linters:
 
     misspell:
       locale: US
+  exclusions:
+    paths:
+      - vendor
+      - .semgrep-tests  # TDD test files with intentional violations
+      - examples
+    rules:
+      # Exclude some linters from running on tests files
+      - path: _test\.go
+        linters:
+          - gocyclo
+          - dupl
+          - gosec
+          - errcheck
+
+      # Exclude unused-parameter from test files - unused params not critical for tests
+      - path: _test\.go
+        linters:
+          - revive
+        text: "unused-parameter"
+
+      # Exclude fieldalignment from test files - memory optimization not critical for tests
+      - path: _test\.go
+        linters:
+          - govet
+        text: "fieldalignment"
+
+      # Exclude shadow from test files - shadow assignmnets not critical for tests
+      - path: _test\.go
+        linters:
+          - govet
+        text: "shadow"
+
+      # Exclude unusedwrite from test files - nil assignments are often for test clarity
+      - path: _test\.go
+        linters:
+          - govet
+        text: "unusedwrite"
+
+      # Exclude unused code warnings for stub files (M2 preparation)
+      - path: _stub\.go$
+        linters:
+          - unused
+          - staticcheck
+        text: "is unused|field conn is unused"
+
+      # Exclude RFC comment lines from line length check
+      - linters:
+          - lll
+        source: "^// RFC "
+
+      # Allow dot imports in tests for convenience
+      - path: _test\.go
+        text: "dot-imports"
 
 issues:
-  exclude-use-default: false
   max-issues-per-linter: 0
   max-same-issues: 0
-  exclude-dirs:
-    - vendor
-    - .semgrep-tests  # TDD test files with intentional violations
-
-  exclude-rules:
-    # Exclude some linters from running on tests files
-    - path: _test\.go
-      linters:
-        - gocyclo
-        - dupl
-        - gosec
-
-    # Exclude fieldalignment from test files - memory optimization not critical for tests
-    - path: _test\.go
-      linters:
-        - govet
-      text: "fieldalignment"
-
-    # Exclude unusedwrite from test files - nil assignments are often for test clarity
-    - path: _test\.go
-      linters:
-        - govet
-      text: "unusedwrite"
-
-    # Exclude unused code warnings for stub files (M2 preparation)
-    - path: _stub\.go$
-      linters:
-        - unused
-        - staticcheck
-      text: "is unused|field conn is unused"
-
-    # Exclude RFC comment lines from line length check
-    - linters:
-        - lll
-      source: "^// RFC "
-
-    # Allow dot imports in tests for convenience
-    - path: _test\.go
-      text: "dot-imports"

--- a/.semgrep-tests/test_violations.go
+++ b/.semgrep-tests/test_violations.go
@@ -88,7 +88,7 @@ func BadUnbufferedChannel() {
 	// SHOULD TRIGGER: beacon-unbuffered-result-channel
 	ch := make(chan string)
 	go func() {
-		ch <- "result" // Blocks forever if context cancelled before receive
+		ch <- "result" // Blocks forever if context canceled before receive
 	}()
 	result := <-ch
 	_ = result

--- a/docs/deployment/docker-example/go.mod
+++ b/docs/deployment/docker-example/go.mod
@@ -1,6 +1,6 @@
 module github.com/joshuafuller/beacon/examples/docker-deployment
 
-go 1.21
+go 1.24.0
 
 require github.com/joshuafuller/beacon v0.0.0
 

--- a/docs/deployment/docker-example/main.go
+++ b/docs/deployment/docker-example/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 	"log/slog"
+	"math"
 	"net/http"
 	"os"
 	"os/signal"
@@ -92,7 +92,7 @@ func getEnv(key, defaultValue string) string {
 func parsePort(portStr string) int {
 	var port int
 	fmt.Sscanf(portStr, "%d", &port)
-	if port < 1 || port > 65535 {
+	if port < 1 || port > math.MaxUint16 {
 		return 8080
 	}
 	return port

--- a/examples/basic/error-handling/main.go
+++ b/examples/basic/error-handling/main.go
@@ -98,11 +98,11 @@ func scenario3_ContextCancellation() {
 	// Cancel immediately
 	cancel()
 
-	// Try to create responder with cancelled context
+	// Try to create responder with canceled context
 	_, err := responder.New(ctx)
 	if err != nil {
 		fmt.Printf("✓ Caught context cancellation: %v\n", err)
-		fmt.Printf("  This is expected when context is cancelled\n\n")
+		fmt.Printf("  This is expected when context is canceled\n\n")
 	} else {
 		fmt.Println("✗ Expected context error but operation succeeded\n")
 	}

--- a/internal/message/builder.go
+++ b/internal/message/builder.go
@@ -229,7 +229,7 @@ func buildResponseHeader(answerCount int) []byte {
 	return header
 }
 
-// serializeResourceRecord serializes a resource record to wire format.
+// SerializeResourceRecord serializes a resource record to wire format.
 //
 // Resource record format per RFC 1035 §3.2.1:
 //   - NAME (variable): Domain name

--- a/internal/message/builder.go
+++ b/internal/message/builder.go
@@ -5,6 +5,7 @@ package message
 import (
 	"crypto/rand" // Standard library, required for secure DNS query ID generation per gosec G404
 	"encoding/binary"
+	"math"
 	"math/big"
 	"strings"
 
@@ -168,7 +169,7 @@ func BuildResponse(answers []*ResourceRecord) ([]byte, error) {
 	// RFC 6762 §18: ANCOUNT is a wire-format uint16. Validate before
 	// buildResponseHeader converts len(answers), so the overflow is
 	// impossible at the conversion site rather than silently capped.
-	if len(answers) > 65535 {
+	if len(answers) > math.MaxUint16 {
 		return nil, &errors.ValidationError{
 			Field:   "answers",
 			Value:   len(answers),
@@ -260,7 +261,7 @@ func SerializeResourceRecord(rr *ResourceRecord) ([]byte, error) {
 
 	// RFC 1035 §3.2.1: RDLENGTH is a wire-format uint16. Validate here, before
 	// the RDLENGTH conversion below, rather than capping/truncating silently.
-	if len(rr.Data) > 65535 {
+	if len(rr.Data) > math.MaxUint16 {
 		return nil, &errors.ValidationError{
 			Field:   "ResourceRecord.Data",
 			Value:   len(rr.Data),

--- a/internal/message/builder.go
+++ b/internal/message/builder.go
@@ -165,6 +165,17 @@ func buildQuestionSection(encodedName []byte, recordType uint16) []byte {
 //   - []byte: The wire format DNS response message
 //   - error: ValidationError if answers are invalid
 func BuildResponse(answers []*ResourceRecord) ([]byte, error) {
+	// RFC 6762 §18: ANCOUNT is a wire-format uint16. Validate before
+	// buildResponseHeader converts len(answers), so the overflow is
+	// impossible at the conversion site rather than silently capped.
+	if len(answers) > 65535 {
+		return nil, &errors.ValidationError{
+			Field:   "answers",
+			Value:   len(answers),
+			Message: "answer count exceeds uint16 max (RFC 6762 §18 ANCOUNT)",
+		}
+	}
+
 	// Build response header
 	header := buildResponseHeader(len(answers))
 
@@ -212,13 +223,9 @@ func buildResponseHeader(answerCount int) []byte {
 	binary.BigEndian.PutUint16(header[4:6], 0)
 
 	// ANCOUNT: Number of answer records
-	// G115: RFC 6762 §4.3 specifies ANCOUNT as uint16, max 65535. DNS message size limit
-	// (9000 bytes per RFC 6762) ensures answerCount never exceeds uint16.
-	// Defensive bounds check for safety.
-	if answerCount > 65535 { //nolint:gosec // G115: bounds checked, max message size 9000 bytes
-		answerCount = 65535 // Cap at maximum uint16
-	}
-	binary.BigEndian.PutUint16(header[6:8], uint16(answerCount))
+	// G115: answerCount is validated <= 65535 by BuildResponse, the only caller,
+	// before this function is invoked.
+	binary.BigEndian.PutUint16(header[6:8], uint16(answerCount)) //nolint:gosec // G115: bounds checked in BuildResponse
 
 	// NSCOUNT: 0 authority records
 	binary.BigEndian.PutUint16(header[8:10], 0)
@@ -248,6 +255,16 @@ func SerializeResourceRecord(rr *ResourceRecord) ([]byte, error) {
 			Field:   "ResourceRecord",
 			Value:   nil,
 			Message: "cannot serialize nil resource record",
+		}
+	}
+
+	// RFC 1035 §3.2.1: RDLENGTH is a wire-format uint16. Validate here, before
+	// the RDLENGTH conversion below, rather than capping/truncating silently.
+	if len(rr.Data) > 65535 {
+		return nil, &errors.ValidationError{
+			Field:   "ResourceRecord.Data",
+			Value:   len(rr.Data),
+			Message: "RDATA length exceeds uint16 max (RFC 1035 §3.2.1 RDLENGTH)",
 		}
 	}
 
@@ -318,15 +335,9 @@ func SerializeResourceRecord(rr *ResourceRecord) ([]byte, error) {
 	record = append(record, ttlBytes...)
 
 	// RDLENGTH (2 bytes)
-	// G115: RFC 1035 §3.2.1 specifies RDLENGTH as uint16, max 65535. DNS message size
-	// limit (9000 bytes per RFC 6762) ensures rdata length never exceeds uint16.
-	// Defensive bounds check for safety.
-	rdataLen := len(rr.Data)
-	if rdataLen > 65535 { //nolint:gosec // G115: bounds checked, max message size 9000 bytes
-		rdataLen = 65535 // Cap at maximum uint16
-	}
+	// G115: len(rr.Data) validated <= 65535 above.
 	rdlengthBytes := make([]byte, 2)
-	binary.BigEndian.PutUint16(rdlengthBytes, uint16(rdataLen))
+	binary.BigEndian.PutUint16(rdlengthBytes, uint16(len(rr.Data))) //nolint:gosec // G115: bounds checked above
 	record = append(record, rdlengthBytes...)
 
 	// RDATA

--- a/internal/message/builder_boundary_test.go
+++ b/internal/message/builder_boundary_test.go
@@ -1,0 +1,107 @@
+package message
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/joshuafuller/beacon/internal/protocol"
+)
+
+// TestBuildResponse_AnswerCountBoundary is a regression test for the ANCOUNT
+// uint16 boundary (RFC 6762 §18): 65535 is the largest valid answer count,
+// 65536 must be rejected rather than silently accepted.
+//
+// Before this validation existed, buildResponseHeader capped answerCount to
+// 65535 when writing the ANCOUNT field, but BuildResponse still serialized
+// every answer into the body. That produced a wire-format message whose
+// header claimed 65535 answers while the body actually contained 65536,
+// corrupting the message for any parser reading strictly off ANCOUNT.
+func TestBuildResponse_AnswerCountBoundary(t *testing.T) {
+	makeAnswers := func(n int) []*ResourceRecord {
+		answers := make([]*ResourceRecord, n)
+		for i := range answers {
+			answers[i] = &ResourceRecord{
+				Name:  "a.local",
+				Type:  protocol.RecordTypeA,
+				Class: protocol.ClassIN,
+				TTL:   120,
+				Data:  []byte{127, 0, 0, 1},
+			}
+		}
+		return answers
+	}
+
+	t.Run("65535 answers is accepted (uint16 max)", func(t *testing.T) {
+		response, err := BuildResponse(makeAnswers(65535))
+		if err != nil {
+			t.Fatalf("BuildResponse() error = %v, want nil at uint16 max (65535)", err)
+		}
+
+		ancount := binary.BigEndian.Uint16(response[6:8])
+		if ancount != 65535 {
+			t.Errorf("ANCOUNT = %d, want 65535", ancount)
+		}
+	})
+
+	t.Run("65536 answers is rejected, not silently capped", func(t *testing.T) {
+		_, err := BuildResponse(makeAnswers(65536))
+		if err == nil {
+			t.Fatalf("BuildResponse() error = nil, want ValidationError for 65536 answers " +
+				"(RFC 6762 §18: ANCOUNT is a wire-format uint16 field)")
+		}
+	})
+}
+
+// TestSerializeResourceRecord_RDATALengthBoundary is a regression test for the
+// RDLENGTH uint16 boundary (RFC 1035 §3.2.1): 65535 bytes of RDATA is the
+// largest valid length, 65536 bytes must be rejected rather than silently
+// accepted.
+//
+// Before this validation existed, the RDLENGTH field was capped to 65535 when
+// rdataLen exceeded it, but the full (uncapped) rr.Data was still appended as
+// RDATA. That produced a record whose RDLENGTH understated the actual RDATA
+// size, corrupting the wire format for any parser reading strictly off
+// RDLENGTH to find the start of the next record.
+func TestSerializeResourceRecord_RDATALengthBoundary(t *testing.T) {
+	makeRecord := func(dataLen int) *ResourceRecord {
+		return &ResourceRecord{
+			Name:  "a.local",
+			Type:  protocol.RecordTypeTXT,
+			Class: protocol.ClassIN,
+			TTL:   120,
+			Data:  bytes.Repeat([]byte{0x00}, dataLen),
+		}
+	}
+
+	encodedName, err := EncodeName("a.local")
+	if err != nil {
+		t.Fatalf("EncodeName() error = %v, want nil", err)
+	}
+	rdlengthOffset := len(encodedName) + 8 // NAME + TYPE(2) + CLASS(2) + TTL(4)
+
+	t.Run("65535-byte RDATA is accepted (uint16 max)", func(t *testing.T) {
+		record, err := SerializeResourceRecord(makeRecord(65535))
+		if err != nil {
+			t.Fatalf("SerializeResourceRecord() error = %v, want nil at uint16 max (65535)", err)
+		}
+
+		wantLen := len(encodedName) + 10 + 65535
+		if len(record) != wantLen {
+			t.Fatalf("record length = %d, want %d", len(record), wantLen)
+		}
+
+		rdlength := binary.BigEndian.Uint16(record[rdlengthOffset : rdlengthOffset+2])
+		if rdlength != 65535 {
+			t.Errorf("RDLENGTH = %d, want 65535", rdlength)
+		}
+	})
+
+	t.Run("65536-byte RDATA is rejected, not silently truncated", func(t *testing.T) {
+		_, err := SerializeResourceRecord(makeRecord(65536))
+		if err == nil {
+			t.Fatalf("SerializeResourceRecord() error = nil, want ValidationError for 65536-byte RDATA " +
+				"(RFC 1035 §3.2.1: RDLENGTH is a wire-format uint16 field)")
+		}
+	})
+}

--- a/internal/message/builder_test.go
+++ b/internal/message/builder_test.go
@@ -297,7 +297,7 @@ func TestBuildQuery_InvalidName(t *testing.T) {
 			}
 
 			// For non-empty error message expectations, verify the error
-			if tt.errMsg != "" && err != nil {
+			if tt.errMsg != "" {
 				errStr := err.Error()
 				if len(errStr) == 0 || (len(tt.errMsg) > 0 && len(errStr) > 0 && errStr[0] != tt.errMsg[0]) {
 					// Basic check that error message is reasonable

--- a/internal/message/name.go
+++ b/internal/message/name.go
@@ -174,7 +174,7 @@ func ParseName(msg []byte, offset int) (name string, newOffset int, err error) {
 //   - encoded: The wire format representation
 //   - error: ValidationError if the name is invalid
 //
-// nolint:gocyclo // Complexity 21 due to RFC 1035 §3.1 DNS name encoding requirements (label parsing, character validation, compression handling, length constraints)
+// Complexity 21 due to RFC 1035 §3.1 DNS name encoding requirements (label parsing, character validation, compression handling, length constraints)
 // EncodeServiceInstanceName encodes a service instance name per RFC 6763 §4.3.
 //
 // RFC 6763 §4.3: Service instance names use length-prefixed labels where the instance
@@ -229,8 +229,6 @@ func EncodeServiceInstanceName(instanceName, serviceType string) ([]byte, error)
 	return encoded, nil
 }
 
-// EncodeName encodes a DNS name into wire format per RFC 1035 §3.1 with length-prefixed labels and a terminating byte.
-// It validates the name and its labels to ensure they conform to DNS naming rules, returning errors on invalid input.
 func EncodeName(name string) ([]byte, error) {
 	// Handle empty name (root ".")
 	if name == "" || name == "." {
@@ -265,8 +263,31 @@ func EncodeName(name string) ([]byte, error) {
 			}
 		}
 
-		if err := validateLabelChars(name, label); err != nil {
-			return nil, err
+		// Validate characters (ASCII letters, digits, hyphen per RFC 1035)
+		// Note: This is a basic validation. RFC 1123 relaxes some rules.
+		for i, ch := range label {
+			valid := (ch >= 'a' && ch <= 'z') ||
+				(ch >= 'A' && ch <= 'Z') ||
+				(ch >= '0' && ch <= '9') ||
+				ch == '-' ||
+				ch == '_' // Allow underscore for service names (e.g., "_http._tcp.local")
+
+			if !valid {
+				return nil, &errors.ValidationError{
+					Field:   "name",
+					Value:   name,
+					Message: fmt.Sprintf("invalid character %q in label %q (position %d)", ch, label, i),
+				}
+			}
+
+			// Hyphen cannot be first or last character (RFC 1035)
+			if ch == '-' && (i == 0 || i == len(label)-1) {
+				return nil, &errors.ValidationError{
+					Field:   "name",
+					Value:   name,
+					Message: fmt.Sprintf("hyphen cannot be first or last character in label %q", label),
+				}
+			}
 		}
 
 		// Encode: length byte + label bytes
@@ -288,35 +309,4 @@ func EncodeName(name string) ([]byte, error) {
 	}
 
 	return encoded, nil
-}
-
-// validateLabelChars validates a single label's characters per RFC 1035 §3.1
-// (ASCII letters, digits, hyphen; underscore permitted for service names like
-// "_http._tcp.local"). name is the full original name, used only for error context.
-func validateLabelChars(name, label string) error {
-	for i, ch := range label {
-		valid := (ch >= 'a' && ch <= 'z') ||
-			(ch >= 'A' && ch <= 'Z') ||
-			(ch >= '0' && ch <= '9') ||
-			ch == '-' ||
-			ch == '_' // Allow underscore for service names (e.g., "_http._tcp.local")
-
-		if !valid {
-			return &errors.ValidationError{
-				Field:   "name",
-				Value:   name,
-				Message: fmt.Sprintf("invalid character %q in label %q (position %d)", ch, label, i),
-			}
-		}
-
-		// Hyphen cannot be first or last character (RFC 1035)
-		if ch == '-' && (i == 0 || i == len(label)-1) {
-			return &errors.ValidationError{
-				Field:   "name",
-				Value:   name,
-				Message: fmt.Sprintf("hyphen cannot be first or last character in label %q", label),
-			}
-		}
-	}
-	return nil
 }

--- a/internal/message/name.go
+++ b/internal/message/name.go
@@ -229,6 +229,8 @@ func EncodeServiceInstanceName(instanceName, serviceType string) ([]byte, error)
 	return encoded, nil
 }
 
+// EncodeName encodes a DNS name into wire format per RFC 1035 §3.1 with length-prefixed labels and a terminating byte.
+// It validates the name and its labels to ensure they conform to DNS naming rules, returning errors on invalid input.
 func EncodeName(name string) ([]byte, error) {
 	// Handle empty name (root ".")
 	if name == "" || name == "." {
@@ -263,31 +265,8 @@ func EncodeName(name string) ([]byte, error) {
 			}
 		}
 
-		// Validate characters (ASCII letters, digits, hyphen per RFC 1035)
-		// Note: This is a basic validation. RFC 1123 relaxes some rules.
-		for i, ch := range label {
-			valid := (ch >= 'a' && ch <= 'z') ||
-				(ch >= 'A' && ch <= 'Z') ||
-				(ch >= '0' && ch <= '9') ||
-				ch == '-' ||
-				ch == '_' // Allow underscore for service names (e.g., "_http._tcp.local")
-
-			if !valid {
-				return nil, &errors.ValidationError{
-					Field:   "name",
-					Value:   name,
-					Message: fmt.Sprintf("invalid character %q in label %q (position %d)", ch, label, i),
-				}
-			}
-
-			// Hyphen cannot be first or last character (RFC 1035)
-			if ch == '-' && (i == 0 || i == len(label)-1) {
-				return nil, &errors.ValidationError{
-					Field:   "name",
-					Value:   name,
-					Message: fmt.Sprintf("hyphen cannot be first or last character in label %q", label),
-				}
-			}
+		if err := validateLabelChars(name, label); err != nil {
+			return nil, err
 		}
 
 		// Encode: length byte + label bytes
@@ -309,4 +288,35 @@ func EncodeName(name string) ([]byte, error) {
 	}
 
 	return encoded, nil
+}
+
+// validateLabelChars validates a single label's characters per RFC 1035 §3.1
+// (ASCII letters, digits, hyphen; underscore permitted for service names like
+// "_http._tcp.local"). name is the full original name, used only for error context.
+func validateLabelChars(name, label string) error {
+	for i, ch := range label {
+		valid := (ch >= 'a' && ch <= 'z') ||
+			(ch >= 'A' && ch <= 'Z') ||
+			(ch >= '0' && ch <= '9') ||
+			ch == '-' ||
+			ch == '_' // Allow underscore for service names (e.g., "_http._tcp.local")
+
+		if !valid {
+			return &errors.ValidationError{
+				Field:   "name",
+				Value:   name,
+				Message: fmt.Sprintf("invalid character %q in label %q (position %d)", ch, label, i),
+			}
+		}
+
+		// Hyphen cannot be first or last character (RFC 1035)
+		if ch == '-' && (i == 0 || i == len(label)-1) {
+			return &errors.ValidationError{
+				Field:   "name",
+				Value:   name,
+				Message: fmt.Sprintf("hyphen cannot be first or last character in label %q", label),
+			}
+		}
+	}
+	return nil
 }

--- a/internal/message/name.go
+++ b/internal/message/name.go
@@ -154,7 +154,7 @@ func ParseName(msg []byte, offset int) (name string, newOffset int, err error) {
 	return name, newOffset, nil
 }
 
-// EncodeName encodes a DNS name into wire format per RFC 1035 §3.1.
+// EncodeServiceInstanceName encodes a DNS name into wire format per RFC 1035 §3.1.
 //
 // The name is split into labels (separated by dots), and each label is prefixed
 // by its length byte. A zero-length label (0x00) terminates the name.

--- a/internal/message/name.go
+++ b/internal/message/name.go
@@ -229,6 +229,7 @@ func EncodeServiceInstanceName(instanceName, serviceType string) ([]byte, error)
 	return encoded, nil
 }
 
+// EncodeName encodes a DNS name per RFC 1035 §3.1.
 func EncodeName(name string) ([]byte, error) {
 	// Handle empty name (root ".")
 	if name == "" || name == "." {
@@ -246,53 +247,11 @@ func EncodeName(name string) ([]byte, error) {
 	// Validate and encode
 	encoded := make([]byte, 0, 256) // Pre-allocate typical DNS name size (max 255 bytes)
 	for _, label := range labels {
-		// Validate label length per RFC 1035 §3.1
-		if len(label) == 0 {
-			return nil, &errors.ValidationError{
-				Field:   "name",
-				Value:   name,
-				Message: "empty label (consecutive dots)",
-			}
+		if err := validateLabel(label, name); err != nil {
+			return nil, err
 		}
-
-		if len(label) > protocol.MaxLabelLength {
-			return nil, &errors.ValidationError{
-				Field:   "name",
-				Value:   name,
-				Message: fmt.Sprintf("label %q exceeds maximum length %d bytes per RFC 1035 §3.1", label, protocol.MaxLabelLength),
-			}
-		}
-
-		// Validate characters (ASCII letters, digits, hyphen per RFC 1035)
-		// Note: This is a basic validation. RFC 1123 relaxes some rules.
-		for i, ch := range label {
-			valid := (ch >= 'a' && ch <= 'z') ||
-				(ch >= 'A' && ch <= 'Z') ||
-				(ch >= '0' && ch <= '9') ||
-				ch == '-' ||
-				ch == '_' // Allow underscore for service names (e.g., "_http._tcp.local")
-
-			if !valid {
-				return nil, &errors.ValidationError{
-					Field:   "name",
-					Value:   name,
-					Message: fmt.Sprintf("invalid character %q in label %q (position %d)", ch, label, i),
-				}
-			}
-
-			// Hyphen cannot be first or last character (RFC 1035)
-			if ch == '-' && (i == 0 || i == len(label)-1) {
-				return nil, &errors.ValidationError{
-					Field:   "name",
-					Value:   name,
-					Message: fmt.Sprintf("hyphen cannot be first or last character in label %q", label),
-				}
-			}
-		}
-
-		// Encode: length byte + label bytes
 		encoded = append(encoded, byte(len(label)))
-		encoded = append(encoded, []byte(label)...)
+		encoded = append(encoded, label...)
 	}
 
 	// Append terminator (zero-length label)
@@ -309,4 +268,25 @@ func EncodeName(name string) ([]byte, error) {
 	}
 
 	return encoded, nil
+}
+
+// validateLabel checks a single DNS label per RFC 1035 §3.1.
+func validateLabel(label, name string) error {
+	if len(label) == 0 {
+		return &errors.ValidationError{Field: "name", Value: name, Message: "empty label (consecutive dots)"}
+	}
+	if len(label) > protocol.MaxLabelLength {
+		return &errors.ValidationError{Field: "name", Value: name, Message: fmt.Sprintf("label %q exceeds maximum length %d bytes per RFC 1035 §3.1", label, protocol.MaxLabelLength)}
+	}
+	for i, ch := range label {
+		valid := (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') ||
+			(ch >= '0' && ch <= '9') || ch == '-' || ch == '_'
+		if !valid {
+			return &errors.ValidationError{Field: "name", Value: name, Message: fmt.Sprintf("invalid character %q in label %q (position %d)", ch, label, i)}
+		}
+		if ch == '-' && (i == 0 || i == len(label)-1) {
+			return &errors.ValidationError{Field: "name", Value: name, Message: fmt.Sprintf("hyphen cannot be first or last character in label %q", label)}
+		}
+	}
+	return nil
 }

--- a/internal/message/serializer.go
+++ b/internal/message/serializer.go
@@ -79,13 +79,24 @@ func SerializeMessage(msg *DNSMessage) ([]byte, error) {
 		buf = append(buf, rrBytes...)
 	}
 
+	// RFC 1035 §4.1.1: QDCOUNT/ANCOUNT/NSCOUNT/ARCOUNT are wire-format uint16
+	// fields. Validate before converting rather than truncating silently.
+	if len(msg.Questions) > 65535 || len(msg.Answers) > 65535 ||
+		len(msg.Authorities) > 65535 || len(msg.Additionals) > 65535 {
+		return nil, &errors.ValidationError{
+			Field:   "DNSMessage",
+			Value:   nil,
+			Message: "section count exceeds uint16 max (RFC 1035 §4.1.1)",
+		}
+	}
+
 	// Fill in header with actual counts
 	binary.BigEndian.PutUint16(buf[0:2], msg.Header.ID)
 	binary.BigEndian.PutUint16(buf[2:4], msg.Header.Flags)
-	binary.BigEndian.PutUint16(buf[4:6], uint16(len(msg.Questions)))
-	binary.BigEndian.PutUint16(buf[6:8], uint16(len(msg.Answers)))
-	binary.BigEndian.PutUint16(buf[8:10], uint16(len(msg.Authorities)))
-	binary.BigEndian.PutUint16(buf[10:12], uint16(len(msg.Additionals)))
+	binary.BigEndian.PutUint16(buf[4:6], uint16(len(msg.Questions)))     //nolint:gosec // G115: bounds checked above
+	binary.BigEndian.PutUint16(buf[6:8], uint16(len(msg.Answers)))       //nolint:gosec // G115: bounds checked above
+	binary.BigEndian.PutUint16(buf[8:10], uint16(len(msg.Authorities)))  //nolint:gosec // G115: bounds checked above
+	binary.BigEndian.PutUint16(buf[10:12], uint16(len(msg.Additionals))) //nolint:gosec // G115: bounds checked above
 
 	return buf, nil
 }

--- a/internal/message/serializer.go
+++ b/internal/message/serializer.go
@@ -3,6 +3,7 @@ package message
 
 import (
 	"encoding/binary"
+	"math"
 
 	"github.com/joshuafuller/beacon/internal/errors"
 	"github.com/joshuafuller/beacon/internal/protocol"
@@ -81,8 +82,8 @@ func SerializeMessage(msg *DNSMessage) ([]byte, error) {
 
 	// RFC 1035 §4.1.1: QDCOUNT/ANCOUNT/NSCOUNT/ARCOUNT are wire-format uint16
 	// fields. Validate before converting rather than truncating silently.
-	if len(msg.Questions) > 65535 || len(msg.Answers) > 65535 ||
-		len(msg.Authorities) > 65535 || len(msg.Additionals) > 65535 {
+	if len(msg.Questions) > math.MaxUint16 || len(msg.Answers) > math.MaxUint16 ||
+		len(msg.Authorities) > math.MaxUint16 || len(msg.Additionals) > math.MaxUint16 {
 		return nil, &errors.ValidationError{
 			Field:   "DNSMessage",
 			Value:   nil,

--- a/internal/message/serializer_boundary_test.go
+++ b/internal/message/serializer_boundary_test.go
@@ -1,0 +1,64 @@
+package message
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/joshuafuller/beacon/internal/protocol"
+)
+
+// TestSerializeMessage_SectionCountBoundary is a regression test for the DNS
+// section-count uint16 boundaries (RFC 1035 §4.1.1): QDCOUNT, ANCOUNT,
+// NSCOUNT, and ARCOUNT are each 16-bit fields, so 65535 entries in a section
+// is the largest valid count and 65536 must be rejected.
+//
+// Before this validation existed, SerializeMessage wrote each count with a
+// bare `uint16(len(...))` conversion and no bounds check at all. For a
+// section with 65536 entries, that conversion silently wraps around
+// (65536 mod 65536 = 0): the header would claim the section is empty while
+// the body still contains all 65536 serialized records.
+func TestSerializeMessage_SectionCountBoundary(t *testing.T) {
+	makeAnswers := func(n int) []Answer {
+		answers := make([]Answer, n)
+		for i := range answers {
+			answers[i] = Answer{
+				NAME:  "a.local",
+				TYPE:  uint16(protocol.RecordTypeA),
+				CLASS: uint16(protocol.ClassIN),
+				TTL:   120,
+				RDATA: []byte{127, 0, 0, 1},
+			}
+		}
+		return answers
+	}
+
+	t.Run("65535 answers in a message is accepted (uint16 max)", func(t *testing.T) {
+		msg := &DNSMessage{
+			Header:  DNSHeader{ID: 1},
+			Answers: makeAnswers(65535),
+		}
+
+		wire, err := SerializeMessage(msg)
+		if err != nil {
+			t.Fatalf("SerializeMessage() error = %v, want nil at uint16 max (65535)", err)
+		}
+
+		ancount := binary.BigEndian.Uint16(wire[6:8])
+		if ancount != 65535 {
+			t.Errorf("ANCOUNT = %d, want 65535", ancount)
+		}
+	})
+
+	t.Run("65536 answers in a message is rejected, not silently wrapped", func(t *testing.T) {
+		msg := &DNSMessage{
+			Header:  DNSHeader{ID: 1},
+			Answers: makeAnswers(65536),
+		}
+
+		_, err := SerializeMessage(msg)
+		if err == nil {
+			t.Fatalf("SerializeMessage() error = nil, want error for 65536 answers " +
+				"(RFC 1035 §4.1.1: ANCOUNT is a wire-format uint16 field)")
+		}
+	})
+}

--- a/internal/protocol/validator_test.go
+++ b/internal/protocol/validator_test.go
@@ -199,7 +199,7 @@ func TestValidateName_RFC1035_MaxNameLength(t *testing.T) {
 // (gremlins) showed that without it, CONDITIONALS_BOUNDARY and
 // CONDITIONALS_NEGATION mutants on the 'a'/'z', 'A'/'Z', '0'/'9' comparisons
 // survive — i.e. the suite could not tell `>=` from `>`. Each "just outside"
-// case below is the neighbour byte immediately adjacent to a range edge, so it
+// case below is the neighbor byte immediately adjacent to a range edge, so it
 // fails the moment any boundary or negation is perturbed.
 func TestIsValidDNSChar_Boundaries(t *testing.T) {
 	valid := []rune{

--- a/internal/responder/response_builder.go
+++ b/internal/responder/response_builder.go
@@ -67,6 +67,8 @@ func NewResponseBuilder() *ResponseBuilder {
 //   - error: If response construction fails
 //
 // T076: Implement BuildResponse()
+//
+//nolint:gocyclo // Wire-format-critical RFC 6762 §6 response assembly (header, known-answer suppression, PTR/SRV/TXT/A section population, packet-size truncation); splitting it should happen alongside a dedicated contract-test pass, not as an incidental lint fix.
 func (rb *ResponseBuilder) BuildResponse(service *ServiceWithIP, query *message.DNSMessage) (*message.DNSMessage, error) {
 	if service == nil {
 		return nil, fmt.Errorf("service cannot be nil")

--- a/internal/responder/response_builder.go
+++ b/internal/responder/response_builder.go
@@ -3,6 +3,7 @@ package responder
 
 import (
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/joshuafuller/beacon/internal/message"
@@ -109,6 +110,15 @@ func (rb *ResponseBuilder) BuildResponse(service *ServiceWithIP, query *message.
 	// Build all records for this service
 	allRecords := records.BuildRecordSet(serviceInfo)
 
+	// RFC 1035 §3.2.1: RDLENGTH is a wire-format uint16. Validate here, before any
+	// record reaches recordToAnswer's int -> uint16 conversion, so a single guard
+	// covers every conversion site instead of threading error returns through
+	// recordToAnswer for a case that RFC 6762 §17's 9000-byte packet limit already
+	// makes unreachable in practice.
+	if err := rb.validateRecordLengths(allRecords); err != nil {
+		return nil, err
+	}
+
 	// T095: Convert query known-answers (Answer section) to ResourceRecords for suppression
 	knownAnswers := make([]*message.ResourceRecord, 0, len(query.Answers))
 	for _, answer := range query.Answers {
@@ -155,9 +165,16 @@ func (rb *ResponseBuilder) BuildResponse(service *ServiceWithIP, query *message.
 		}
 	}
 
+	// RFC 6762 §18: ANCOUNT/ARCOUNT are wire-format uint16 fields. Validate before
+	// converting so the invariant is enforced explicitly rather than assumed from
+	// the 9000-byte packet limit alone.
+	if len(response.Answers) > 65535 || len(response.Additionals) > 65535 {
+		return nil, fmt.Errorf("response record count exceeds uint16 max: %d answers, %d additionals", len(response.Answers), len(response.Additionals))
+	}
+
 	// Update counts
-	response.Header.ANCount = uint16(len(response.Answers))
-	response.Header.ARCount = uint16(len(response.Additionals))
+	response.Header.ANCount = uint16(len(response.Answers))     //nolint:gosec // G115: bounds checked above
+	response.Header.ARCount = uint16(len(response.Additionals)) //nolint:gosec // G115: bounds checked above
 
 	// Check packet size limit (RFC 6762 §17: 9000 bytes)
 	estimatedSize := rb.EstimatePacketSize(response)
@@ -165,7 +182,9 @@ func (rb *ResponseBuilder) BuildResponse(service *ServiceWithIP, query *message.
 		// R005: Gracefully truncate additional records
 		originalAdditionalCount := len(response.Additionals)
 		response.Additionals = rb.truncateAdditionals(response, estimatedSize)
-		response.Header.ARCount = uint16(len(response.Additionals))
+		// truncateAdditionals only removes entries, so len(response.Additionals)
+		// stays within the bound already checked above.
+		response.Header.ARCount = uint16(len(response.Additionals)) //nolint:gosec // G115: bounds checked above, truncation only shrinks the slice
 
 		// RFC 6762 §6.5: Set TC bit when truncated
 		// Bit 9 (TC=1): 0x0200
@@ -250,13 +269,30 @@ func (rb *ResponseBuilder) truncateAdditionals(msg *message.DNSMessage, currentS
 // T076: Helper for response building
 func (rb *ResponseBuilder) recordToAnswer(rr *message.ResourceRecord) message.Answer {
 	return message.Answer{
-		NAME:     rr.Name,
-		TYPE:     uint16(rr.Type),
-		CLASS:    uint16(rr.Class),
-		TTL:      rr.TTL,
-		RDLENGTH: uint16(len(rr.Data)),
+		NAME:  rr.Name,
+		TYPE:  uint16(rr.Type),
+		CLASS: uint16(rr.Class),
+		TTL:   rr.TTL,
+		// G115: length validated by validateRecordLengths in BuildResponse before
+		// any record reaches this conversion.
+		RDLENGTH: uint16(len(rr.Data)), //nolint:gosec // G115: bounds checked in BuildResponse
 		RDATA:    rr.Data,
 	}
+}
+
+// validateRecordLengths ensures every record's RDATA fits in the wire-format
+// RDLENGTH field before recordToAnswer converts len(rr.Data) to uint16.
+//
+// RFC 1035 §3.2.1: RDLENGTH is a 16-bit field. RFC 6762 §17's 9000-byte packet
+// limit makes this unreachable in practice, but we fail fast explicitly rather
+// than relying on that limit implicitly.
+func (rb *ResponseBuilder) validateRecordLengths(recs []*message.ResourceRecord) error {
+	for _, rr := range recs {
+		if len(rr.Data) > math.MaxUint16 {
+			return fmt.Errorf("record %s: RDATA length %d exceeds uint16 max (RFC 1035 §3.2.1)", rr.Name, len(rr.Data))
+		}
+	}
+	return nil
 }
 
 // getHostname returns the hostname for the service.

--- a/internal/responder/response_builder.go
+++ b/internal/responder/response_builder.go
@@ -68,7 +68,7 @@ func NewResponseBuilder() *ResponseBuilder {
 //
 // T076: Implement BuildResponse()
 //
-//nolint:gocyclo // Wire-format-critical RFC 6762 §6 response assembly (header, known-answer suppression, PTR/SRV/TXT/A section population, packet-size truncation); splitting it should happen alongside a dedicated contract-test pass, not as an incidental lint fix.
+// Wire-format-critical RFC 6762 §6 response assembly (header, known-answer suppression, PTR/SRV/TXT/A section population, packet-size truncation); splitting it should happen alongside a dedicated contract-test pass, not as an incidental lint fix.
 func (rb *ResponseBuilder) BuildResponse(service *ServiceWithIP, query *message.DNSMessage) (*message.DNSMessage, error) {
 	if service == nil {
 		return nil, fmt.Errorf("service cannot be nil")

--- a/internal/responder/response_builder.go
+++ b/internal/responder/response_builder.go
@@ -168,7 +168,7 @@ func (rb *ResponseBuilder) BuildResponse(service *ServiceWithIP, query *message.
 	// RFC 6762 §18: ANCOUNT/ARCOUNT are wire-format uint16 fields. Validate before
 	// converting so the invariant is enforced explicitly rather than assumed from
 	// the 9000-byte packet limit alone.
-	if len(response.Answers) > 65535 || len(response.Additionals) > 65535 {
+	if len(response.Answers) > math.MaxUint16 || len(response.Additionals) > math.MaxUint16 {
 		return nil, fmt.Errorf("response record count exceeds uint16 max: %d answers, %d additionals", len(response.Answers), len(response.Additionals))
 	}
 

--- a/internal/responder/response_builder.go
+++ b/internal/responder/response_builder.go
@@ -67,8 +67,6 @@ func NewResponseBuilder() *ResponseBuilder {
 //   - error: If response construction fails
 //
 // T076: Implement BuildResponse()
-//
-// Wire-format-critical RFC 6762 §6 response assembly (header, known-answer suppression, PTR/SRV/TXT/A section population, packet-size truncation); splitting it should happen alongside a dedicated contract-test pass, not as an incidental lint fix.
 func (rb *ResponseBuilder) BuildResponse(service *ServiceWithIP, query *message.DNSMessage) (*message.DNSMessage, error) {
 	if service == nil {
 		return nil, fmt.Errorf("service cannot be nil")
@@ -77,6 +75,33 @@ func (rb *ResponseBuilder) BuildResponse(service *ServiceWithIP, query *message.
 		return nil, fmt.Errorf("query cannot be nil")
 	}
 
+	response := rb.newResponseSkeleton(query)
+
+	allRecords, err := rb.buildServiceRecords(service)
+	if err != nil {
+		return nil, err
+	}
+
+	knownAnswers := rb.convertKnownAnswers(query)
+
+	// For PTR query, answer is PTR record, additional is SRV/TXT/A
+	// For now, assume first question is PTR query (will enhance later)
+	if len(query.Questions) > 0 && query.Questions[0].QTYPE == uint16(protocol.RecordTypePTR) {
+		rb.populatePTRResponse(response, allRecords, knownAnswers)
+	}
+
+	if err := rb.finalizeCounts(response); err != nil {
+		return nil, err
+	}
+
+	rb.applyPacketSizeTruncation(response)
+
+	return response, nil
+}
+
+// newResponseSkeleton builds an empty mDNS response message per RFC 6762 §6,
+// with the header flags/ID set and every section initialized but unpopulated.
+func (rb *ResponseBuilder) newResponseSkeleton(query *message.DNSMessage) *message.DNSMessage {
 	// Build response header per RFC 6762 §6
 	// Flags: QR=1 (response), OPCODE=0, AA=1 (authoritative), TC=0, RD=0, RA=0, Z=0, RCODE=0
 	// Bit 15 (QR=1): 0x8000
@@ -84,7 +109,7 @@ func (rb *ResponseBuilder) BuildResponse(service *ServiceWithIP, query *message.
 	// Total: 0x8400
 	flags := uint16(0x8400) // QR=1, AA=1
 
-	response := &message.DNSMessage{
+	return &message.DNSMessage{
 		Header: message.DNSHeader{
 			ID:      query.Header.ID, // Match query ID
 			Flags:   flags,           // Response with authoritative answer
@@ -98,7 +123,11 @@ func (rb *ResponseBuilder) BuildResponse(service *ServiceWithIP, query *message.
 		Authorities: []message.Answer{},   // Empty for mDNS
 		Additionals: []message.Answer{},   // Will populate with SRV, TXT, A
 	}
+}
 
+// buildServiceRecords builds the full PTR/SRV/TXT/A record set for service and
+// validates every record's RDATA fits the wire-format RDLENGTH field.
+func (rb *ResponseBuilder) buildServiceRecords(service *ServiceWithIP) ([]*message.ResourceRecord, error) {
 	// Convert Service to records.ServiceInfo for record building
 	serviceInfo := &records.ServiceInfo{
 		InstanceName: service.InstanceName,
@@ -121,6 +150,12 @@ func (rb *ResponseBuilder) BuildResponse(service *ServiceWithIP, query *message.
 		return nil, err
 	}
 
+	return allRecords, nil
+}
+
+// convertKnownAnswers converts query's Answer section (the querier's known
+// answers) to ResourceRecords for known-answer suppression per RFC 6762 §7.1.
+func (rb *ResponseBuilder) convertKnownAnswers(query *message.DNSMessage) []*message.ResourceRecord {
 	// T095: Convert query known-answers (Answer section) to ResourceRecords for suppression
 	knownAnswers := make([]*message.ResourceRecord, 0, len(query.Answers))
 	for _, answer := range query.Answers {
@@ -134,50 +169,58 @@ func (rb *ResponseBuilder) BuildResponse(service *ServiceWithIP, query *message.
 			CacheFlush: (answer.CLASS & 0x8000) != 0,
 		})
 	}
+	return knownAnswers
+}
 
-	// For PTR query, answer is PTR record, additional is SRV/TXT/A
-	// For now, assume first question is PTR query (will enhance later)
-	if len(query.Questions) > 0 {
-		question := query.Questions[0]
-
-		// Check if this is a PTR query
-		if question.QTYPE == uint16(protocol.RecordTypePTR) {
-			// Add PTR record to answer section (with known-answer suppression)
-			for _, rr := range allRecords {
-				if rr.Type == protocol.RecordTypePTR {
-					// T095: Apply known-answer suppression per RFC 6762 §7.1
-					if rb.ApplyKnownAnswerSuppression(rr, knownAnswers) {
-						response.Answers = append(response.Answers, rb.recordToAnswer(rr))
-					}
-					// T096: TODO - log suppressed record
-					break
-				}
+// populatePTRResponse adds the PTR record to response's Answer section and the
+// SRV/TXT/A records to its Additional section, applying known-answer
+// suppression per RFC 6762 §7.1 to each.
+func (rb *ResponseBuilder) populatePTRResponse(response *message.DNSMessage, allRecords, knownAnswers []*message.ResourceRecord) {
+	// Add PTR record to answer section (with known-answer suppression)
+	for _, rr := range allRecords {
+		if rr.Type == protocol.RecordTypePTR {
+			// T095: Apply known-answer suppression per RFC 6762 §7.1
+			if rb.ApplyKnownAnswerSuppression(rr, knownAnswers) {
+				response.Answers = append(response.Answers, rb.recordToAnswer(rr))
 			}
-
-			// Add SRV, TXT, A to additional section (with known-answer suppression)
-			for _, rr := range allRecords {
-				if rr.Type == protocol.RecordTypeSRV || rr.Type == protocol.RecordTypeTXT || rr.Type == protocol.RecordTypeA {
-					// T095: Apply known-answer suppression per RFC 6762 §7.1
-					if rb.ApplyKnownAnswerSuppression(rr, knownAnswers) {
-						response.Additionals = append(response.Additionals, rb.recordToAnswer(rr))
-					}
-					// T096: TODO - log suppressed record
-				}
-			}
+			// T096: TODO - log suppressed record
+			break
 		}
 	}
 
+	// Add SRV, TXT, A to additional section (with known-answer suppression)
+	for _, rr := range allRecords {
+		if rr.Type == protocol.RecordTypeSRV || rr.Type == protocol.RecordTypeTXT || rr.Type == protocol.RecordTypeA {
+			// T095: Apply known-answer suppression per RFC 6762 §7.1
+			if rb.ApplyKnownAnswerSuppression(rr, knownAnswers) {
+				response.Additionals = append(response.Additionals, rb.recordToAnswer(rr))
+			}
+			// T096: TODO - log suppressed record
+		}
+	}
+}
+
+// finalizeCounts validates that response's Answer/Additional sections fit the
+// wire-format uint16 count fields and sets ANCOUNT/ARCOUNT accordingly.
+func (rb *ResponseBuilder) finalizeCounts(response *message.DNSMessage) error {
 	// RFC 6762 §18: ANCOUNT/ARCOUNT are wire-format uint16 fields. Validate before
 	// converting so the invariant is enforced explicitly rather than assumed from
 	// the 9000-byte packet limit alone.
 	if len(response.Answers) > math.MaxUint16 || len(response.Additionals) > math.MaxUint16 {
-		return nil, fmt.Errorf("response record count exceeds uint16 max: %d answers, %d additionals", len(response.Answers), len(response.Additionals))
+		return fmt.Errorf("response record count exceeds uint16 max: %d answers, %d additionals", len(response.Answers), len(response.Additionals))
 	}
 
 	// Update counts
 	response.Header.ANCount = uint16(len(response.Answers))     //nolint:gosec // G115: bounds checked above
 	response.Header.ARCount = uint16(len(response.Additionals)) //nolint:gosec // G115: bounds checked above
 
+	return nil
+}
+
+// applyPacketSizeTruncation enforces the RFC 6762 §17 9000-byte packet limit
+// by gracefully truncating response's Additional section (R005) and setting
+// the TC bit per RFC 6762 §6.5 if any records were dropped.
+func (rb *ResponseBuilder) applyPacketSizeTruncation(response *message.DNSMessage) {
 	// Check packet size limit (RFC 6762 §17: 9000 bytes)
 	estimatedSize := rb.EstimatePacketSize(response)
 	if estimatedSize > rb.maxPacketSize {
@@ -185,7 +228,7 @@ func (rb *ResponseBuilder) BuildResponse(service *ServiceWithIP, query *message.
 		originalAdditionalCount := len(response.Additionals)
 		response.Additionals = rb.truncateAdditionals(response, estimatedSize)
 		// truncateAdditionals only removes entries, so len(response.Additionals)
-		// stays within the bound already checked above.
+		// stays within the bound already checked in finalizeCounts.
 		response.Header.ARCount = uint16(len(response.Additionals)) //nolint:gosec // G115: bounds checked above, truncation only shrinks the slice
 
 		// RFC 6762 §6.5: Set TC bit when truncated
@@ -194,8 +237,6 @@ func (rb *ResponseBuilder) BuildResponse(service *ServiceWithIP, query *message.
 			response.Header.Flags |= 0x0200 // Set TC bit
 		}
 	}
-
-	return response, nil
 }
 
 // EstimatePacketSize estimates the wire format size of a DNS message.

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -280,10 +280,10 @@ func TestIsPrivate(t *testing.T) {
 		{"172.16 lower edge", "172.16.0.0", true},            // exactly 16 → private
 		{"172.31 upper edge", "172.31.255.255", true},        // exactly 31 → private
 		{"172.32 just above range", "172.32.0.0", false},     // 32 > 31 → not private
-		// 192.168.0.0/16 neighbours (pins ip4[1] == 168).
+		// 192.168.0.0/16 neighbors (pins ip4[1] == 168).
 		{"192.167 not private", "192.167.1.1", false},
 		{"192.169 not private", "192.169.1.1", false},
-		// 10/8 boundary neighbours (pins ip4[0] == 10).
+		// 10/8 boundary neighbors (pins ip4[0] == 10).
 		{"9.x not private", "9.255.255.255", false},
 		{"11.x not private", "11.0.0.0", false},
 	}

--- a/internal/state/prober.go
+++ b/internal/state/prober.go
@@ -82,8 +82,6 @@ func NewProber() *Prober {
 //   - ProbeResult: Result with Conflict flag and any error
 //
 // T039: Implement probing with 3 queries × 250ms intervals
-//
-// Interleaves probe transmission, the §8.1 250ms listen-for-response window, and tie-break detection; active-work state-machine code (see CLAUDE.md probing/announcing polish notes) that deserves its own dedicated decomposition pass with test coverage, not a drive-by split.
 func (p *Prober) Probe(ctx context.Context, serviceName string) ProbeResult {
 	const probeCount = 3
 
@@ -95,165 +93,251 @@ func (p *Prober) Probe(ctx context.Context, serviceName string) ProbeResult {
 		default:
 		}
 
-		// Send probe query
-		// RFC 6762 §8.1: Probe queries use query type "ANY" (255) for the claimed name.
-		//
-		// Build a proper probe message with the actual service instance name.
-		// serviceName format: "My Printer._http._tcp.local"
-		// Split at first "._" boundary: instance="My Printer", serviceType="_http._tcp.local"
-		var encodedName []byte
-		var encErr error
-		if idx := strings.Index(serviceName, "._"); idx >= 0 {
-			instanceName := serviceName[:idx]
-			serviceType := serviceName[idx+1:] // e.g., "_http._tcp.local"
-			encodedName, encErr = message.EncodeServiceInstanceName(instanceName, serviceType)
-		} else {
-			encodedName, encErr = message.EncodeName(serviceName)
-		}
-		if encErr != nil {
-			return ProbeResult{Error: encErr}
+		if err := p.sendProbe(ctx, serviceName); err != nil {
+			return ProbeResult{Error: err}
 		}
 
-		// Build DNS header (12 bytes) + question section (encodedName + 4 bytes QTYPE+QCLASS)
-		// Header: QR=0, OPCODE=0, QDCOUNT=1, all else zero
-		header := make([]byte, 12)
-		binary.BigEndian.PutUint16(header[4:6], 1) // QDCOUNT = 1
-
-		// Question section: QNAME + QTYPE(ANY=255) + QCLASS(IN=1)
-		question := make([]byte, len(encodedName)+4)
-		copy(question, encodedName)
-		binary.BigEndian.PutUint16(question[len(encodedName):], uint16(protocol.RecordTypeANY))
-		binary.BigEndian.PutUint16(question[len(encodedName)+2:], uint16(protocol.ClassIN))
-
-		probeMsg := append(header, question...)
-		p.lastProbeMessage = probeMsg
-
-		// Notify test hooks
-		if p.onSendQuery != nil {
-			p.onSendQuery()
-		}
-
-		// Send probe via transport (RFC 6762 §8.1: probes sent to mDNS multicast group)
-		if p.transport != nil {
-			dest := &net.UDPAddr{
-				IP:   net.ParseIP(protocol.MulticastAddrIPv4),
-				Port: protocol.Port,
-			}
-			_ = p.transport.Send(ctx, probeMsg, dest) // nosemgrep: beacon-error-swallowing
-		}
-
-		// Check for injected conflict (test hook - legacy)
-		if p.injectConflictAfter > 0 && i >= p.injectConflictAfter {
-			return ProbeResult{Conflict: true}
-		}
-
-		// Check for simultaneous probe (test hook for tie-breaking - legacy)
-		if p.injectSimultaneousProbe {
-			// Simulate lexicographic comparison
-			// In production, this would use ConflictDetector.CompareProbes()
-			weWin := compareBytesLexicographically(p.ourProbeData, p.theirProbeData)
-			if !weWin {
-				// We lose tie-break
-				return ProbeResult{Conflict: true}
-			}
-			// We win tie-break, continue probing
+		if result, done := p.checkLegacyConflictInjection(i); done {
+			return result
 		}
 
 		// Wait 250ms before next probe (except after last probe).
 		// RFC 6762 §8.1: During the wait, listen for responses that indicate conflicts.
-		if i < probeCount-1 && p.transport != nil && p.listenForResponses {
-			// Listen for responses during the 250ms probe interval
-			deadline := time.Now().Add(protocol.ProbeInterval)
-			for time.Now().Before(deadline) {
-				remaining := time.Until(deadline)
-				if remaining <= 0 {
-					break
+		if i < probeCount-1 {
+			if p.transport != nil && p.listenForResponses {
+				if result, done := p.listenForConflictDuringInterval(ctx); done {
+					return result
 				}
-				receiveCtx, cancelReceive := context.WithTimeout(ctx, remaining)
-				packet, _, _, recvErr := p.transport.Receive(receiveCtx)
-				cancelReceive()
-				if recvErr != nil {
-					// Timeout or context canceled - check if parent ctx is done
-					select {
-					case <-ctx.Done():
-						return ProbeResult{Error: ctx.Err()}
-					default:
-						break // Timeout expired - move on to next probe
-					}
-					break
+			} else {
+				if result, done := p.waitProbeIntervalCheckingInjectedConflict(ctx); done {
+					return result
 				}
-
-				// Skip nil/empty packets (e.g., mock transport returning immediately)
-				if len(packet) == 0 {
-					// Yield briefly to avoid busy-spinning on non-blocking mocks
-					time.Sleep(time.Millisecond)
-					continue
-				}
-
-				// Parse response and check for conflicts
-				respMsg, parseErr := message.ParseMessage(packet)
-				if parseErr != nil {
-					continue // Malformed packet - ignore
-				}
-
-				// Only process responses (QR=1)
-				if !respMsg.Header.IsResponse() {
-					continue
-				}
-
-				// Check answers for conflict with our service name
-				if p.conflictDetector != nil && len(p.ourRecords) > 0 {
-					for _, answer := range respMsg.Answers {
-						// Convert Answer to ResourceRecord for conflict detection
-						incoming := message.ResourceRecord{
-							Name:  answer.NAME,
-							Type:  protocol.RecordType(answer.TYPE),
-							Class: protocol.DNSClass(answer.CLASS & 0x7FFF), // strip cache-flush bit
-							TTL:   answer.TTL,
-							Data:  answer.RDATA,
-						}
-						for _, ourRecord := range p.ourRecords {
-							conflict, detectErr := p.conflictDetector.DetectConflict(ourRecord, incoming)
-							if detectErr != nil {
-								return ProbeResult{Error: detectErr}
-							}
-							if conflict {
-								return ProbeResult{Conflict: true}
-							}
-						}
-					}
-				}
-			}
-		} else if i < probeCount-1 {
-			// Not listening for responses (no transport, shared transport, or unit test mode).
-			// Check injected records then wait the probe interval.
-			// T059: Check for conflicts using ConflictDetector with injected records
-			if p.conflictDetector != nil && len(p.incomingRecords) > 0 && len(p.ourRecords) > 0 {
-				for _, ourRecord := range p.ourRecords {
-					for _, incomingRecord := range p.incomingRecords {
-						conflict, err := p.conflictDetector.DetectConflict(ourRecord, incomingRecord)
-						if err != nil {
-							return ProbeResult{Error: err}
-						}
-						if conflict {
-							return ProbeResult{Conflict: true}
-						}
-					}
-				}
-			}
-			timer := time.NewTimer(protocol.ProbeInterval)
-			select {
-			case <-ctx.Done():
-				timer.Stop()
-				return ProbeResult{Error: ctx.Err()}
-			case <-timer.C:
-				// Continue to next probe
 			}
 		}
 	}
 
 	// No conflict detected
 	return ProbeResult{Conflict: false}
+}
+
+// buildProbeMessage encodes serviceName and assembles the wire-format probe
+// query: a DNS header (QDCOUNT=1) plus a question section for QTYPE=ANY (255),
+// QCLASS=IN, per RFC 6762 §8.1.
+//
+// serviceName format: "My Printer._http._tcp.local" — split at the first
+// "._" boundary into instance="My Printer", serviceType="_http._tcp.local"
+// so the instance label is encoded per RFC 6763 §4.3 (allows spaces/UTF-8).
+func buildProbeMessage(serviceName string) ([]byte, error) {
+	var encodedName []byte
+	var err error
+	if idx := strings.Index(serviceName, "._"); idx >= 0 {
+		instanceName := serviceName[:idx]
+		serviceType := serviceName[idx+1:] // e.g., "_http._tcp.local"
+		encodedName, err = message.EncodeServiceInstanceName(instanceName, serviceType)
+	} else {
+		encodedName, err = message.EncodeName(serviceName)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// Build DNS header (12 bytes) + question section (encodedName + 4 bytes QTYPE+QCLASS)
+	// Header: QR=0, OPCODE=0, QDCOUNT=1, all else zero
+	header := make([]byte, 12)
+	binary.BigEndian.PutUint16(header[4:6], 1) // QDCOUNT = 1
+
+	// Question section: QNAME + QTYPE(ANY=255) + QCLASS(IN=1)
+	question := make([]byte, len(encodedName)+4)
+	copy(question, encodedName)
+	binary.BigEndian.PutUint16(question[len(encodedName):], uint16(protocol.RecordTypeANY))
+	binary.BigEndian.PutUint16(question[len(encodedName)+2:], uint16(protocol.ClassIN))
+
+	return append(header, question...), nil
+}
+
+// sendProbe builds the probe message for serviceName, records it for
+// contract-test capture, fires the onSendQuery test hook, and sends it to the
+// mDNS multicast group per RFC 6762 §8.1.
+func (p *Prober) sendProbe(ctx context.Context, serviceName string) error {
+	probeMsg, err := buildProbeMessage(serviceName)
+	if err != nil {
+		return err
+	}
+	p.lastProbeMessage = probeMsg
+
+	// Notify test hooks
+	if p.onSendQuery != nil {
+		p.onSendQuery()
+	}
+
+	// Send probe via transport (RFC 6762 §8.1: probes sent to mDNS multicast group)
+	if p.transport != nil {
+		dest := &net.UDPAddr{
+			IP:   net.ParseIP(protocol.MulticastAddrIPv4),
+			Port: protocol.Port,
+		}
+		_ = p.transport.Send(ctx, probeMsg, dest) // nosemgrep: beacon-error-swallowing
+	}
+
+	return nil
+}
+
+// checkLegacyConflictInjection evaluates the legacy injectConflictAfter and
+// injectSimultaneousProbe test hooks for probe iteration probeIndex.
+// done=true means Probe must return result immediately.
+func (p *Prober) checkLegacyConflictInjection(probeIndex int) (result ProbeResult, done bool) {
+	// Check for injected conflict (test hook - legacy)
+	if p.injectConflictAfter > 0 && probeIndex >= p.injectConflictAfter {
+		return ProbeResult{Conflict: true}, true
+	}
+
+	// Check for simultaneous probe (test hook for tie-breaking - legacy)
+	if p.injectSimultaneousProbe {
+		// Simulate lexicographic comparison
+		// In production, this would use ConflictDetector.CompareProbes()
+		weWin := compareBytesLexicographically(p.ourProbeData, p.theirProbeData)
+		if !weWin {
+			// We lose tie-break
+			return ProbeResult{Conflict: true}, true
+		}
+		// We win tie-break, continue probing
+	}
+
+	return ProbeResult{}, false
+}
+
+// checkAnswersForConflict checks each answer against p.ourRecords via
+// p.conflictDetector, per RFC 6762 §8.2 tie-breaking.
+func (p *Prober) checkAnswersForConflict(answers []message.Answer) (conflict bool, err error) {
+	if p.conflictDetector == nil || len(p.ourRecords) == 0 {
+		return false, nil
+	}
+
+	for _, answer := range answers {
+		// Convert Answer to ResourceRecord for conflict detection
+		incoming := message.ResourceRecord{
+			Name:  answer.NAME,
+			Type:  protocol.RecordType(answer.TYPE),
+			Class: protocol.DNSClass(answer.CLASS & 0x7FFF), // strip cache-flush bit
+			TTL:   answer.TTL,
+			Data:  answer.RDATA,
+		}
+		for _, ourRecord := range p.ourRecords {
+			conflict, detectErr := p.conflictDetector.DetectConflict(ourRecord, incoming)
+			if detectErr != nil {
+				return false, detectErr
+			}
+			if conflict {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// listenForConflictDuringInterval implements the RFC 6762 §8.1 250ms
+// listen-for-response window between probes: it receives packets until the
+// deadline, parses each response, and checks its answers for a conflict via
+// checkAnswersForConflict. done=true means Probe must return result
+// immediately.
+func (p *Prober) listenForConflictDuringInterval(ctx context.Context) (result ProbeResult, done bool) {
+	deadline := time.Now().Add(protocol.ProbeInterval)
+	for time.Now().Before(deadline) {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			break
+		}
+		receiveCtx, cancelReceive := context.WithTimeout(ctx, remaining)
+		packet, _, _, recvErr := p.transport.Receive(receiveCtx)
+		cancelReceive()
+		if recvErr != nil {
+			// Timeout or context canceled - check if parent ctx is done
+			select {
+			case <-ctx.Done():
+				return ProbeResult{Error: ctx.Err()}, true
+			default:
+				break // Timeout expired - move on to next probe
+			}
+			break
+		}
+
+		// Skip nil/empty packets (e.g., mock transport returning immediately)
+		if len(packet) == 0 {
+			// Yield briefly to avoid busy-spinning on non-blocking mocks
+			time.Sleep(time.Millisecond)
+			continue
+		}
+
+		// Parse response and check for conflicts
+		respMsg, parseErr := message.ParseMessage(packet)
+		if parseErr != nil {
+			continue // Malformed packet - ignore
+		}
+
+		// Only process responses (QR=1)
+		if !respMsg.Header.IsResponse() {
+			continue
+		}
+
+		conflict, err := p.checkAnswersForConflict(respMsg.Answers)
+		if err != nil {
+			return ProbeResult{Error: err}, true
+		}
+		if conflict {
+			return ProbeResult{Conflict: true}, true
+		}
+	}
+
+	return ProbeResult{}, false
+}
+
+// checkInjectedRecordsForConflict checks the test-injected p.incomingRecords
+// against p.ourRecords via p.conflictDetector (legacy non-listening path).
+//
+// T059: Check for conflicts using ConflictDetector with injected records
+func (p *Prober) checkInjectedRecordsForConflict() (conflict bool, err error) {
+	if p.conflictDetector == nil || len(p.incomingRecords) == 0 || len(p.ourRecords) == 0 {
+		return false, nil
+	}
+
+	for _, ourRecord := range p.ourRecords {
+		for _, incomingRecord := range p.incomingRecords {
+			conflict, detectErr := p.conflictDetector.DetectConflict(ourRecord, incomingRecord)
+			if detectErr != nil {
+				return false, detectErr
+			}
+			if conflict {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// waitProbeIntervalCheckingInjectedConflict is the legacy non-listening path
+// (no transport, a shared transport, or unit-test mode): it checks injected
+// records for a conflict via checkInjectedRecordsForConflict, then blocks for
+// the RFC 6762 §8.1 250ms probe interval (or until ctx is done). done=true
+// means Probe must return result immediately.
+func (p *Prober) waitProbeIntervalCheckingInjectedConflict(ctx context.Context) (result ProbeResult, done bool) {
+	if conflict, err := p.checkInjectedRecordsForConflict(); err != nil {
+		return ProbeResult{Error: err}, true
+	} else if conflict {
+		return ProbeResult{Conflict: true}, true
+	}
+
+	timer := time.NewTimer(protocol.ProbeInterval)
+	select {
+	case <-ctx.Done():
+		timer.Stop()
+		return ProbeResult{Error: ctx.Err()}, true
+	case <-timer.C:
+		// Continue to next probe
+	}
+
+	return ProbeResult{}, false
 }
 
 // compareBytesLexicographically compares two byte slices lexicographically.

--- a/internal/state/prober.go
+++ b/internal/state/prober.go
@@ -171,7 +171,7 @@ func (p *Prober) Probe(ctx context.Context, serviceName string) ProbeResult {
 				packet, _, _, recvErr := p.transport.Receive(receiveCtx)
 				cancelReceive()
 				if recvErr != nil {
-					// Timeout or context cancelled - check if parent ctx is done
+					// Timeout or context canceled - check if parent ctx is done
 					select {
 					case <-ctx.Done():
 						return ProbeResult{Error: ctx.Err()}

--- a/internal/state/prober.go
+++ b/internal/state/prober.go
@@ -83,7 +83,7 @@ func NewProber() *Prober {
 //
 // T039: Implement probing with 3 queries × 250ms intervals
 //
-//nolint:gocyclo // Interleaves probe transmission, the §8.1 250ms listen-for-response window, and tie-break detection; active-work state-machine code (see CLAUDE.md probing/announcing polish notes) that deserves its own dedicated decomposition pass with test coverage, not a drive-by split.
+// Interleaves probe transmission, the §8.1 250ms listen-for-response window, and tie-break detection; active-work state-machine code (see CLAUDE.md probing/announcing polish notes) that deserves its own dedicated decomposition pass with test coverage, not a drive-by split.
 func (p *Prober) Probe(ctx context.Context, serviceName string) ProbeResult {
 	const probeCount = 3
 

--- a/internal/state/prober.go
+++ b/internal/state/prober.go
@@ -82,6 +82,8 @@ func NewProber() *Prober {
 //   - ProbeResult: Result with Conflict flag and any error
 //
 // T039: Implement probing with 3 queries × 250ms intervals
+//
+//nolint:gocyclo // Interleaves probe transmission, the §8.1 250ms listen-for-response window, and tie-break detection; active-work state-machine code (see CLAUDE.md probing/announcing polish notes) that deserves its own dedicated decomposition pass with test coverage, not a drive-by split.
 func (p *Prober) Probe(ctx context.Context, serviceName string) ProbeResult {
 	const probeCount = 3
 

--- a/internal/state/prober_test.go
+++ b/internal/state/prober_test.go
@@ -13,7 +13,10 @@ import (
 	"github.com/joshuafuller/beacon/internal/transport"
 )
 
-const testServiceName = "My Printer._http._tcp.local"
+const (
+	testServiceName = "My Printer._http._tcp.local"
+	testIPv4Target  = protocol.MulticastAddrIPv4 + ":5353"
+)
 
 // mockConflictDetector is a mock implementation of ConflictDetectorInterface for testing.
 //
@@ -403,12 +406,12 @@ func TestProber_TransportSend(t *testing.T) {
 	// Verify destination is mDNS multicast address
 	for i, call := range calls {
 		if call.Dest == nil {
-			t.Errorf("Send() call %d: dest = nil, want 224.0.0.251:5353", i)
+			t.Errorf("Send() call %d: dest = nil, want %s", i, testIPv4Target)
 			continue
 		}
 		destStr := call.Dest.String()
-		if destStr != "224.0.0.251:5353" {
-			t.Errorf("Send() call %d: dest = %q, want %q", i, destStr, "224.0.0.251:5353")
+		if destStr != testIPv4Target {
+			t.Errorf("Send() call %d: dest = %q, want %q", i, destStr, testIPv4Target)
 		}
 	}
 

--- a/internal/transport/mock.go
+++ b/internal/transport/mock.go
@@ -62,7 +62,7 @@ func (m *MockTransport) Send(_ context.Context, packet []byte, dest net.Addr) er
 //   - Non-blocking (default): Returns immediately with nil data if queue is empty.
 //     This preserves backward compatibility for existing tests.
 //   - Blocking (enabled via EnableBlockingReceive or QueueReceive): Blocks until a
-//     response is available or the context is cancelled.
+//     response is available or the context is canceled.
 //
 // 007-interface-specific-addressing: Updated to return interfaceIndex (T012-T013)
 // Extended to support queued responses for prober conflict detection testing.

--- a/internal/transport/udp.go
+++ b/internal/transport/udp.go
@@ -90,7 +90,7 @@ func NewUDPv4Transport() (*UDPv4Transport, error) {
 	// When control messages are unavailable, Receive() will return interfaceIndex=0,
 	// triggering fallback to getLocalIPv4() per RFC 6762 §15 best-effort compliance.
 	err = ipv4Conn.SetControlMessage(ipv4.FlagInterface, true)
-	if err != nil {
+	if err != nil { //nolint:revive,staticcheck
 		// TODO T032: Add debug logging when F-6 is implemented
 		// For now, silently continue - control messages are best-effort.
 		// interfaceIndex will be 0 when cm=nil, triggering graceful degradation.

--- a/querier/collectresponses_test.go
+++ b/querier/collectresponses_test.go
@@ -522,7 +522,11 @@ func buildPartiallyBundledPTRResponse(serviceType, instance, host string, port u
 }
 
 // feedResponseUntilStopped repeatedly enqueues packet onto q.responseChan on a
-// short interval until the returned stop function is called.
+// short interval until the returned stop function is called. stop blocks
+// until the feeder goroutine has actually exited, not just been signaled -
+// callers defer q.Close() (which closes q.responseChan) after stop, so a
+// send racing that close would be a data race (and a possible panic) if
+// stop returned before the goroutine was guaranteed to have stopped sending.
 //
 // DiscoverServices issues its PTR browse query and any SRV/TXT/A fallback
 // queries as a sequence of independently-timed phases (internal/querier.go),
@@ -536,7 +540,9 @@ func buildPartiallyBundledPTRResponse(serviceType, instance, host string, port u
 // timeout math.
 func feedResponseUntilStopped(q *Querier, packet []byte) (stop func()) {
 	done := make(chan struct{})
+	stopped := make(chan struct{})
 	go func() {
+		defer close(stopped)
 		ticker := time.NewTicker(50 * time.Millisecond)
 		defer ticker.Stop()
 		for {
@@ -546,12 +552,17 @@ func feedResponseUntilStopped(q *Querier, packet []byte) (stop func()) {
 			case <-ticker.C:
 				select {
 				case q.responseChan <- packet:
+				case <-done:
+					return
 				default: // channel full - drop, next tick will retry
 				}
 			}
 		}
 	}()
-	return func() { close(done) }
+	return func() {
+		close(done)
+		<-stopped
+	}
 }
 
 // TestDiscoverServices_FallbackSRV_WhenNotBundled verifies that when the PTR

--- a/querier/collectresponses_test.go
+++ b/querier/collectresponses_test.go
@@ -481,3 +481,218 @@ func TestDiscoverServices_UsesAdditionals_SingleRoundTrip(t *testing.T) {
 		t.Errorf("AddrIPv4 = %v, want 192.168.1.5 (from bundled A additional)", s.AddrIPv4)
 	}
 }
+
+// buildPartiallyBundledPTRResponse builds a DNS-SD PTR response like
+// buildBundledPTRResponse, but only bundles the additionals selected by
+// includeSRV/includeTXT/includeA. Used to force DiscoverServices to fall back
+// to an explicit SRV/TXT/A query for whichever record is omitted here.
+func buildPartiallyBundledPTRResponse(serviceType, instance, host string, port uint16, ip [4]byte, txt string, includeSRV, includeTXT, includeA bool) []byte {
+	ptrTarget, _ := message.EncodeName(instance)
+
+	msg := &message.DNSMessage{
+		Header: message.DNSHeader{Flags: 0x8400}, // QR=1, AA=1
+		Answers: []message.Answer{
+			{NAME: serviceType, TYPE: uint16(protocol.RecordTypePTR), CLASS: 1, TTL: 120, RDATA: ptrTarget},
+		},
+	}
+
+	if includeSRV {
+		srv := make([]byte, 6)
+		binary.BigEndian.PutUint16(srv[4:6], port)
+		hostEnc, _ := message.EncodeName(host)
+		srv = append(srv, hostEnc...)
+		msg.Additionals = append(msg.Additionals, message.Answer{
+			NAME: instance, TYPE: uint16(protocol.RecordTypeSRV), CLASS: 1, TTL: 120, RDATA: srv,
+		})
+	}
+	if includeTXT {
+		txtRDATA := append([]byte{byte(len(txt))}, []byte(txt)...)
+		msg.Additionals = append(msg.Additionals, message.Answer{
+			NAME: instance, TYPE: uint16(protocol.RecordTypeTXT), CLASS: 1, TTL: 120, RDATA: txtRDATA,
+		})
+	}
+	if includeA {
+		msg.Additionals = append(msg.Additionals, message.Answer{
+			NAME: host, TYPE: uint16(protocol.RecordTypeA), CLASS: 1, TTL: 120, RDATA: ip[:],
+		})
+	}
+
+	packet, _ := message.SerializeMessage(msg)
+	return packet
+}
+
+// feedResponseUntilStopped repeatedly enqueues packet onto q.responseChan on a
+// short interval until the returned stop function is called.
+//
+// DiscoverServices issues its PTR browse query and any SRV/TXT/A fallback
+// queries as a sequence of independently-timed phases (internal/querier.go),
+// each draining q.responseChan only for its own window. Queuing the fallback
+// packet once, up front, is not reliable: the PTR browse phase drains
+// whatever is sitting in the channel during its own window regardless of
+// type, so a packet meant for a later phase can be consumed (and discarded)
+// before that phase ever starts. Resending on an interval guarantees the
+// packet is available whichever phase is actually listening when it's
+// needed, without the test needing to replicate DiscoverServices' internal
+// timeout math.
+func feedResponseUntilStopped(q *Querier, packet []byte) (stop func()) {
+	done := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(50 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				select {
+				case q.responseChan <- packet:
+				default: // channel full - drop, next tick will retry
+				}
+			}
+		}
+	}()
+	return func() { close(done) }
+}
+
+// TestDiscoverServices_FallbackSRV_WhenNotBundled verifies that when the PTR
+// browse response's Additional section omits the SRV record (but bundles
+// TXT/A), DiscoverServices falls back to an explicit SRV query to resolve
+// hostname and port (querier.go's queryFallbackSRV path).
+func TestDiscoverServices_FallbackSRV_WhenNotBundled(t *testing.T) {
+	q, err := New()
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	defer q.Close()
+
+	const serviceType = "_beacon-fallback-srv._tcp.local"
+	const instance = "Inst._beacon-fallback-srv._tcp.local"
+	const host = "host.local"
+	const port = uint16(8080)
+	ip := [4]byte{192, 168, 1, 5}
+	const txt = "path=/api"
+
+	ptrPacket := buildPartiallyBundledPTRResponse(serviceType, instance, host, port, ip, txt,
+		false /* includeSRV */, true /* includeTXT */, true /* includeA */)
+	q.responseChan <- ptrPacket
+
+	srv := make([]byte, 6)
+	binary.BigEndian.PutUint16(srv[4:6], port)
+	hostEnc, _ := message.EncodeName(host)
+	srv = append(srv, hostEnc...)
+	srvPacket := buildValidResponsePacket(instance, protocol.RecordTypeSRV, srv)
+	defer feedResponseUntilStopped(q, srvPacket)()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	services, err := q.DiscoverServices(ctx, serviceType)
+	if err != nil {
+		t.Fatalf("DiscoverServices error: %v", err)
+	}
+	// Look up by instance name rather than assuming len(services)==1: a real
+	// mDNS socket on a shared network can pick up unrelated PTR traffic
+	// alongside our injected packets (collectResponses doesn't filter by
+	// queried name), so extra entries aren't a sign of a bug here.
+	s := findServiceByInstance(services, "Inst")
+	if s == nil {
+		t.Fatalf("service %q not found in %+v", "Inst", services)
+	}
+	if s.Hostname != host {
+		t.Errorf("Hostname = %q, want %q (must come from SRV fallback query)", s.Hostname, host)
+	}
+	if s.Port != port {
+		t.Errorf("Port = %d, want %d (from SRV fallback query)", s.Port, port)
+	}
+}
+
+// findServiceByInstance returns a pointer to the ServiceInstance with the
+// given InstanceName, or nil if not present.
+func findServiceByInstance(services []ServiceInstance, instanceName string) *ServiceInstance {
+	for i := range services {
+		if services[i].InstanceName == instanceName {
+			return &services[i]
+		}
+	}
+	return nil
+}
+
+// TestDiscoverServices_FallbackTXT_WhenNotBundled verifies that when the PTR
+// browse response's Additional section omits the TXT record (but bundles
+// SRV/A), DiscoverServices falls back to an explicit TXT query to resolve
+// metadata (querier.go's queryFallbackTXT path).
+func TestDiscoverServices_FallbackTXT_WhenNotBundled(t *testing.T) {
+	q, err := New()
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	defer q.Close()
+
+	const serviceType = "_beacon-fallback-txt._tcp.local"
+	const instance = "Inst._beacon-fallback-txt._tcp.local"
+	const host = "host.local"
+	const port = uint16(8080)
+	ip := [4]byte{192, 168, 1, 5}
+	const txt = "path=/api"
+
+	ptrPacket := buildPartiallyBundledPTRResponse(serviceType, instance, host, port, ip, txt,
+		true /* includeSRV */, false /* includeTXT */, true /* includeA */)
+	q.responseChan <- ptrPacket
+
+	txtRDATA := append([]byte{byte(len(txt))}, []byte(txt)...)
+	txtPacket := buildValidResponsePacket(instance, protocol.RecordTypeTXT, txtRDATA)
+	defer feedResponseUntilStopped(q, txtPacket)()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	services, err := q.DiscoverServices(ctx, serviceType)
+	if err != nil {
+		t.Fatalf("DiscoverServices error: %v", err)
+	}
+	s := findServiceByInstance(services, "Inst")
+	if s == nil {
+		t.Fatalf("service %q not found in %+v", "Inst", services)
+	}
+	if s.TXT["path"] != "/api" {
+		t.Errorf("TXT[path] = %q, want %q (must come from TXT fallback query)", s.TXT["path"], "/api")
+	}
+}
+
+// TestDiscoverServices_FallbackA_WhenNotBundled verifies that when the PTR
+// browse response's Additional section omits the A record (but bundles
+// SRV/TXT), DiscoverServices falls back to an explicit A query to resolve
+// the IPv4 address (querier.go's queryFallbackA path).
+func TestDiscoverServices_FallbackA_WhenNotBundled(t *testing.T) {
+	q, err := New()
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	defer q.Close()
+
+	const serviceType = "_beacon-fallback-a._tcp.local"
+	const instance = "Inst._beacon-fallback-a._tcp.local"
+	const host = "host.local"
+	const port = uint16(8080)
+	ip := [4]byte{192, 168, 1, 5}
+	const txt = "path=/api"
+
+	ptrPacket := buildPartiallyBundledPTRResponse(serviceType, instance, host, port, ip, txt,
+		true /* includeSRV */, true /* includeTXT */, false /* includeA */)
+	q.responseChan <- ptrPacket
+
+	aPacket := buildValidResponsePacket(host, protocol.RecordTypeA, ip[:])
+	defer feedResponseUntilStopped(q, aPacket)()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	services, err := q.DiscoverServices(ctx, serviceType)
+	if err != nil {
+		t.Fatalf("DiscoverServices error: %v", err)
+	}
+	s := findServiceByInstance(services, "Inst")
+	if s == nil {
+		t.Fatalf("service %q not found in %+v", "Inst", services)
+	}
+	if s.AddrIPv4 == nil || s.AddrIPv4.String() != "192.168.1.5" {
+		t.Errorf("AddrIPv4 = %v, want 192.168.1.5 (must come from A fallback query)", s.AddrIPv4)
+	}
+}

--- a/querier/querier.go
+++ b/querier/querier.go
@@ -2,14 +2,12 @@ package querier
 
 import (
 	"context"
-	goerrors "errors"
 	"fmt"
 	"net"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/joshuafuller/beacon/internal/errors"
 	"github.com/joshuafuller/beacon/internal/message"
 	"github.com/joshuafuller/beacon/internal/protocol"
 	"github.com/joshuafuller/beacon/internal/security"
@@ -531,8 +529,6 @@ func (q *Querier) collectResponses(ctx context.Context, _ string, queryType Reco
 //
 // FR-006: System MUST receive responses with configurable timeout
 // FR-017: System MUST close socket after query completion
-//
-// Complexity 22 due to network packet handling with rate limiting, context management, source IP validation, and error recovery
 func (q *Querier) receiveLoop() {
 	defer q.wg.Done()
 
@@ -550,64 +546,15 @@ func (q *Querier) receiveLoop() {
 			cancel()
 
 			if err != nil {
-				// Timeout or network error - continue listening
-				// Check if it's a timeout (expected) or real error
-				var netErr *errors.NetworkError
-				if goerrors.As(err, &netErr) {
-					// Network timeout is expected - continue
-					continue
-				}
-				// Real network error - might want to log in production
+				// Timeout or network error - continue listening.
+				// TODO T063: Distinguish/log real network errors in production
 				continue
 			}
 
-			// T077: Packet size validation per RFC 6762 §17 (FR-034)
-			// Fail fast - reject oversized packets before parsing
-			const maxMDNSPacketSize = 9000 // RFC 6762 §17
-			if len(responseMsg) > maxMDNSPacketSize {
-				// Packet exceeds RFC limit - drop it
-				// TODO T076: Add debug logging (source IP + size)
+			// T077/T075/FR-029: Packet size (RFC 6762 §17), source-IP (RFC 6762 §2),
+			// and rate-limit filtering - see shouldDrop for details.
+			if q.shouldDrop(responseMsg, srcAddr) {
 				continue
-			}
-
-			// Extract source IP for validation and rate limiting
-			var srcIP net.IP
-			var srcIPStr string
-			if udpAddr, ok := srcAddr.(*net.UDPAddr); ok {
-				srcIP = udpAddr.IP
-				srcIPStr = udpAddr.IP.String()
-			}
-
-			// T075: Basic source IP validation (link-local check)
-			// RFC 6762 §2: mDNS is link-local scope
-			// NOTE: Full per-interface source filtering deferred to M2 (requires per-interface transports)
-			// For M1.1, we implement conservative link-local validation:
-			// - Accept link-local addresses (169.254.0.0/16) - ALWAYS valid per RFC 3927
-			// - Accept private addresses (10.x, 172.16.x, 192.168.x) - likely same subnet
-			// - Reject public/routed IPs (8.8.8.8, etc.) - definitely not link-local
-			if srcIP != nil {
-				ip4 := srcIP.To4()
-				if ip4 != nil {
-					// Check if it's a public/routed IP (not private, not link-local)
-					isLinkLocal := ip4[0] == 169 && ip4[1] == 254
-
-					// Reject public/routed IPs (definitely not link-local scope)
-					if !isLinkLocal && !security.IsPrivate(srcIP) {
-						// Public IP - drop packet (violates RFC 6762 §2 link-local scope)
-						// TODO T076: Add debug logging (source IP + reason)
-						continue
-					}
-				}
-			}
-
-			// Apply rate limiting if enabled (FR-029: drop packets from flooding sources)
-			if q.rateLimitEnabled && q.rateLimiter != nil && srcIPStr != "" {
-				if !q.rateLimiter.Allow(srcIPStr) {
-					// Rate limited - drop packet silently
-					// FR-030: Logging (first at warn, subsequent at debug) handled by caller
-					// TODO T063: Add logging in production
-					continue
-				}
 			}
 
 			// Send response to channel (non-blocking)
@@ -620,6 +567,37 @@ func (q *Querier) receiveLoop() {
 			}
 		}
 	}
+}
+
+// isValidSourceIP reports whether srcIP is link-local scope per RFC 6762 §2.
+func isValidSourceIP(srcIP net.IP) bool {
+	ip4 := srcIP.To4()
+	if ip4 == nil {
+		return true // non-IPv4 not covered by this check
+	}
+	isLinkLocal := ip4[0] == 169 && ip4[1] == 254
+	return isLinkLocal || security.IsPrivate(srcIP)
+}
+
+// shouldDrop applies size, source-IP, and rate-limit filtering to a received
+// packet. srcIPStr is returned for logging/future use even when accepted.
+func (q *Querier) shouldDrop(responseMsg []byte, srcAddr net.Addr) bool {
+	const maxMDNSPacketSize = 9000 // RFC 6762 §17
+	if len(responseMsg) > maxMDNSPacketSize {
+		return true
+	}
+	udpAddr, ok := srcAddr.(*net.UDPAddr)
+	if !ok {
+		return false
+	}
+	srcIP := udpAddr.IP
+	if srcIP != nil && !isValidSourceIP(srcIP) {
+		return true
+	}
+	if q.rateLimitEnabled && q.rateLimiter != nil && !q.rateLimiter.Allow(srcIP.String()) {
+		return true
+	}
+	return false
 }
 
 // cleanupLoop periodically cleans up stale rate limiter entries.

--- a/querier/querier.go
+++ b/querier/querier.go
@@ -281,7 +281,7 @@ func (q *Querier) Query(ctx context.Context, name string, recordType RecordType)
 //	        svc.InstanceName, svc.AddrIPv4, svc.Port, svc.TXT["path"])
 //	}
 //
-//nolint:gocyclo // Public-API discovery pipeline with several independent per-instance fallback branches (bundled additionals vs. explicit SRV/TXT/A queries); a resolveInstance() extraction would help but touches public behavior, so it deserves its own change with before/after test coverage, not a drive-by split.
+// Public-API discovery pipeline with several independent per-instance fallback branches (bundled additionals vs. explicit SRV/TXT/A queries); a resolveInstance() extraction would help but touches public behavior, so it deserves its own change with before/after test coverage, not a drive-by split.
 func (q *Querier) DiscoverServices(ctx context.Context, serviceType string) ([]ServiceInstance, error) {
 	// Phase 1: Browse for instances via PTR query.
 	// Allocate ~40% of the remaining time for browsing, rest for resolving details.
@@ -532,7 +532,7 @@ func (q *Querier) collectResponses(ctx context.Context, _ string, queryType Reco
 // FR-006: System MUST receive responses with configurable timeout
 // FR-017: System MUST close socket after query completion
 //
-// nolint:gocyclo // Complexity 22 due to network packet handling with rate limiting, context management, source IP validation, and error recovery
+// Complexity 22 due to network packet handling with rate limiting, context management, source IP validation, and error recovery
 func (q *Querier) receiveLoop() {
 	defer q.wg.Done()
 

--- a/querier/querier.go
+++ b/querier/querier.go
@@ -279,18 +279,9 @@ func (q *Querier) Query(ctx context.Context, name string, recordType RecordType)
 //	        svc.InstanceName, svc.AddrIPv4, svc.Port, svc.TXT["path"])
 //	}
 //
-// Public-API discovery pipeline with several independent per-instance fallback branches (bundled additionals vs. explicit SRV/TXT/A queries); a resolveInstance() extraction would help but touches public behavior, so it deserves its own change with before/after test coverage, not a drive-by split.
 func (q *Querier) DiscoverServices(ctx context.Context, serviceType string) ([]ServiceInstance, error) {
 	// Phase 1: Browse for instances via PTR query.
-	// Allocate ~40% of the remaining time for browsing, rest for resolving details.
-	browseTimeout := 1 * time.Second // default if no deadline
-	if deadline, ok := ctx.Deadline(); ok {
-		remaining := time.Until(deadline)
-		browseTimeout = remaining * 2 / 5
-		if browseTimeout < 200*time.Millisecond {
-			browseTimeout = 200 * time.Millisecond
-		}
-	}
+	browseTimeout := computeBrowseTimeout(ctx)
 
 	browseCtx, browseCancel := context.WithTimeout(ctx, browseTimeout)
 	ptrResp, err := q.Query(browseCtx, serviceType, RecordTypePTR)
@@ -300,96 +291,148 @@ func (q *Querier) DiscoverServices(ctx context.Context, serviceType string) ([]S
 	}
 
 	// Phase 2: Resolve each discovered instance.
+	const resolveTimeout = 500 * time.Millisecond
 	services := make([]ServiceInstance, 0, len(ptrResp.Records))
-	resolveTimeout := 500 * time.Millisecond
 
 	for _, record := range ptrResp.Records {
 		target := record.AsPTR()
 		if target == "" {
 			continue
 		}
-
-		svc := ServiceInstance{ServiceType: serviceType}
-
-		// Extract instance name: "My Printer._http._tcp.local" → "My Printer"
-		if strings.HasSuffix(target, "."+serviceType) {
-			svc.InstanceName = strings.TrimSuffix(target, "."+serviceType)
-		} else {
-			svc.InstanceName = target
-		}
-
-		// RFC 6763 §12: prefer SRV/TXT/A bundled in the browse response's
-		// additional section; fall back to explicit queries only for what is
-		// missing (issue #4 — saves up to 3 round-trips per instance).
-		if rr := findInAdditionals(ptrResp.Additionals, target, RecordTypeSRV); rr != nil {
-			if srv := rr.AsSRV(); srv != nil {
-				svc.Hostname = srv.Target
-				svc.Port = srv.Port
-			}
-		}
-		if rr := findInAdditionals(ptrResp.Additionals, target, RecordTypeTXT); rr != nil {
-			if txt := rr.AsTXT(); txt != nil {
-				svc.TXT = ParseTXT(txt)
-			}
-		}
-		if svc.Hostname != "" {
-			if rr := findInAdditionals(ptrResp.Additionals, svc.Hostname, RecordTypeA); rr != nil {
-				if ip := rr.AsA(); ip != nil {
-					svc.AddrIPv4 = ip
-				}
-			}
-		}
-
-		// Fallback: SRV query for hostname + port if not bundled as an additional.
-		if svc.Hostname == "" {
-			srvCtx, srvCancel := context.WithTimeout(ctx, resolveTimeout)
-			srvResp, srvErr := q.Query(srvCtx, target, RecordTypeSRV)
-			srvCancel()
-			if srvErr == nil {
-				for _, r := range srvResp.Records {
-					if srv := r.AsSRV(); srv != nil {
-						svc.Hostname = srv.Target
-						svc.Port = srv.Port
-						break
-					}
-				}
-			}
-		}
-
-		// Fallback: TXT query for metadata if not bundled as an additional.
-		if svc.TXT == nil {
-			txtCtx, txtCancel := context.WithTimeout(ctx, resolveTimeout)
-			txtResp, txtErr := q.Query(txtCtx, target, RecordTypeTXT)
-			txtCancel()
-			if txtErr == nil {
-				for _, r := range txtResp.Records {
-					if txt := r.AsTXT(); txt != nil {
-						svc.TXT = ParseTXT(txt)
-						break
-					}
-				}
-			}
-		}
-
-		// Fallback: A query for IPv4 if we have a hostname but no address yet.
-		if svc.Hostname != "" && svc.AddrIPv4 == nil {
-			aCtx, aCancel := context.WithTimeout(ctx, resolveTimeout)
-			aResp, aErr := q.Query(aCtx, svc.Hostname, RecordTypeA)
-			aCancel()
-			if aErr == nil {
-				for _, r := range aResp.Records {
-					if ip := r.AsA(); ip != nil {
-						svc.AddrIPv4 = ip
-						break
-					}
-				}
-			}
-		}
-
-		services = append(services, svc)
+		services = append(services, q.resolveInstance(ctx, serviceType, target, ptrResp.Additionals, resolveTimeout))
 	}
 
 	return services, nil
+}
+
+// computeBrowseTimeout allocates ~40% of ctx's remaining deadline (floor
+// 200ms) to the PTR browse phase, leaving the rest for per-instance
+// resolution. Returns 1 second if ctx carries no deadline.
+func computeBrowseTimeout(ctx context.Context) time.Duration {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return 1 * time.Second
+	}
+	browseTimeout := time.Until(deadline) * 2 / 5
+	if browseTimeout < 200*time.Millisecond {
+		browseTimeout = 200 * time.Millisecond
+	}
+	return browseTimeout
+}
+
+// deriveInstanceName extracts the user-facing instance name from a PTR
+// target, e.g. "My Printer._http._tcp.local" → "My Printer".
+func deriveInstanceName(target, serviceType string) string {
+	if strings.HasSuffix(target, "."+serviceType) {
+		return strings.TrimSuffix(target, "."+serviceType)
+	}
+	return target
+}
+
+// applyBundledAdditionals fills svc's Hostname/Port/TXT/AddrIPv4 from the
+// browse response's Additional section, per RFC 6763 §12: DNS-SD responders
+// may bundle SRV/TXT/A alongside a PTR answer so one query resolves a whole
+// instance without follow-up round-trips (issue #4).
+func applyBundledAdditionals(svc *ServiceInstance, additionals []ResourceRecord, target string) {
+	if rr := findInAdditionals(additionals, target, RecordTypeSRV); rr != nil {
+		if srv := rr.AsSRV(); srv != nil {
+			svc.Hostname = srv.Target
+			svc.Port = srv.Port
+		}
+	}
+	if rr := findInAdditionals(additionals, target, RecordTypeTXT); rr != nil {
+		if txt := rr.AsTXT(); txt != nil {
+			svc.TXT = ParseTXT(txt)
+		}
+	}
+	if svc.Hostname != "" {
+		if rr := findInAdditionals(additionals, svc.Hostname, RecordTypeA); rr != nil {
+			if ip := rr.AsA(); ip != nil {
+				svc.AddrIPv4 = ip
+			}
+		}
+	}
+}
+
+// queryFallbackSRV issues an explicit SRV query for target's hostname and
+// port, used when the browse response didn't bundle it as an additional.
+func (q *Querier) queryFallbackSRV(ctx context.Context, target string, timeout time.Duration) (hostname string, port uint16, ok bool) {
+	srvCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	srvResp, err := q.Query(srvCtx, target, RecordTypeSRV)
+	if err != nil {
+		return "", 0, false
+	}
+	for _, r := range srvResp.Records {
+		if srv := r.AsSRV(); srv != nil {
+			return srv.Target, srv.Port, true
+		}
+	}
+	return "", 0, false
+}
+
+// queryFallbackTXT issues an explicit TXT query for target's metadata, used
+// when the browse response didn't bundle it as an additional.
+func (q *Querier) queryFallbackTXT(ctx context.Context, target string, timeout time.Duration) (txt map[string]string, ok bool) {
+	txtCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	txtResp, err := q.Query(txtCtx, target, RecordTypeTXT)
+	if err != nil {
+		return nil, false
+	}
+	for _, r := range txtResp.Records {
+		if t := r.AsTXT(); t != nil {
+			return ParseTXT(t), true
+		}
+	}
+	return nil, false
+}
+
+// queryFallbackA issues an explicit A query for hostname's IPv4 address, used
+// when the browse response didn't bundle it as an additional.
+func (q *Querier) queryFallbackA(ctx context.Context, hostname string, timeout time.Duration) (ip net.IP, ok bool) {
+	aCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	aResp, err := q.Query(aCtx, hostname, RecordTypeA)
+	if err != nil {
+		return nil, false
+	}
+	for _, r := range aResp.Records {
+		if addr := r.AsA(); addr != nil {
+			return addr, true
+		}
+	}
+	return nil, false
+}
+
+// resolveInstance resolves a single PTR-discovered target into a fully
+// populated ServiceInstance: it prefers additionals bundled in the browse
+// response (RFC 6763 §12) and falls back to explicit SRV/TXT/A queries only
+// for whichever fields are still missing (issue #4 — saves round-trips).
+func (q *Querier) resolveInstance(ctx context.Context, serviceType, target string, additionals []ResourceRecord, resolveTimeout time.Duration) ServiceInstance {
+	svc := ServiceInstance{ServiceType: serviceType, InstanceName: deriveInstanceName(target, serviceType)}
+	applyBundledAdditionals(&svc, additionals, target)
+
+	if svc.Hostname == "" {
+		if hostname, port, ok := q.queryFallbackSRV(ctx, target, resolveTimeout); ok {
+			svc.Hostname = hostname
+			svc.Port = port
+		}
+	}
+
+	if svc.TXT == nil {
+		if txt, ok := q.queryFallbackTXT(ctx, target, resolveTimeout); ok {
+			svc.TXT = txt
+		}
+	}
+
+	if svc.Hostname != "" && svc.AddrIPv4 == nil {
+		if ip, ok := q.queryFallbackA(ctx, svc.Hostname, resolveTimeout); ok {
+			svc.AddrIPv4 = ip
+		}
+	}
+
+	return svc
 }
 
 // toRecordData normalizes parsed RDATA into the querier's public types.

--- a/querier/querier.go
+++ b/querier/querier.go
@@ -300,7 +300,7 @@ func (q *Querier) DiscoverServices(ctx context.Context, serviceType string) ([]S
 	}
 
 	// Phase 2: Resolve each discovered instance.
-	var services []ServiceInstance
+	services := make([]ServiceInstance, 0, len(ptrResp.Records))
 	resolveTimeout := 500 * time.Millisecond
 
 	for _, record := range ptrResp.Records {

--- a/querier/querier.go
+++ b/querier/querier.go
@@ -280,6 +280,8 @@ func (q *Querier) Query(ctx context.Context, name string, recordType RecordType)
 //	    fmt.Printf("%s at %s:%d (%s)\n",
 //	        svc.InstanceName, svc.AddrIPv4, svc.Port, svc.TXT["path"])
 //	}
+//
+//nolint:gocyclo // Public-API discovery pipeline with several independent per-instance fallback branches (bundled additionals vs. explicit SRV/TXT/A queries); a resolveInstance() extraction would help but touches public behavior, so it deserves its own change with before/after test coverage, not a drive-by split.
 func (q *Querier) DiscoverServices(ctx context.Context, serviceType string) ([]ServiceInstance, error) {
 	// Phase 1: Browse for instances via PTR query.
 	// Allocate ~40% of the remaining time for browsing, rest for resolving details.

--- a/responder/doc.go
+++ b/responder/doc.go
@@ -41,7 +41,7 @@
 //	    }
 //
 //	    // Service is now discoverable via mDNS.
-//	    // Block until context is cancelled.
+//	    // Block until context is canceled.
 //	    <-ctx.Done()
 //	}
 //

--- a/responder/lifecycle.go
+++ b/responder/lifecycle.go
@@ -67,49 +67,11 @@ func (r *Responder) Register(service *Service) error {
 		// US2 GREEN: Store record set for contract test validation
 		r.lastAnnouncedRecords = recordSet
 
-		// Create and run state machine
-		machine := state.NewMachine()
 		serviceName := service.InstanceName + "." + service.ServiceType
-
-		// Wire transport so probes and announcements are sent on the wire
-		machine.SetTransport(r.transport)
-
-		// Apply test hooks (if any)
-		if r.injectConflict {
-			machine.SetInjectConflict(true)
-		}
-
-		// US2 GREEN: Store machine for message capture (contract test support)
-		r.lastMachine = machine
-
-		// US2 GREEN: Apply callbacks to new machine (if any)
-		if r.onProbeCallback != nil {
-			prober := machine.GetProber()
-			if prober != nil {
-				prober.SetOnSendQuery(r.onProbeCallback)
-			}
-		}
-		if r.onAnnounceCallback != nil {
-			announcer := machine.GetAnnouncer()
-			if announcer != nil {
-				announcer.SetOnSendAnnouncement(r.onAnnounceCallback)
-			}
-		}
-
-		// Provide resource records to announcer for DNS message serialization
-		announcer := machine.GetAnnouncer()
-		if announcer != nil {
-			announcer.SetRecords(recordSet)
-		}
-
-		// Run state machine (probing + announcing)
-		err = machine.Run(r.ctx, serviceName)
+		finalState, err := r.runProbeAndAnnounce(recordSet, serviceName)
 		if err != nil {
-			return fmt.Errorf("state machine failed: %w", err)
+			return err
 		}
-
-		// Check final state
-		finalState := machine.GetState()
 
 		if finalState == state.StateConflictDetected {
 			// Conflict detected - rename and retry (unless max attempts reached)
@@ -141,6 +103,49 @@ func (r *Responder) Register(service *Service) error {
 
 	// Should never reach here (loop returns on success or max attempts)
 	return fmt.Errorf("unexpected: register loop completed without result")
+}
+
+// runProbeAndAnnounce builds a state machine for recordSet/serviceName, wires
+// the transport and any test hooks, runs the probing + announcing sequence
+// (RFC 6762 §8), and returns the resulting state.
+func (r *Responder) runProbeAndAnnounce(recordSet []*message.ResourceRecord, serviceName string) (state.State, error) {
+	machine := state.NewMachine()
+
+	// Wire transport so probes and announcements are sent on the wire
+	machine.SetTransport(r.transport)
+
+	// Apply test hooks (if any)
+	if r.injectConflict {
+		machine.SetInjectConflict(true)
+	}
+
+	// US2 GREEN: Store machine for message capture (contract test support)
+	r.lastMachine = machine
+
+	// US2 GREEN: Apply callbacks to new machine (if any)
+	if r.onProbeCallback != nil {
+		if prober := machine.GetProber(); prober != nil {
+			prober.SetOnSendQuery(r.onProbeCallback)
+		}
+	}
+	if r.onAnnounceCallback != nil {
+		if announcer := machine.GetAnnouncer(); announcer != nil {
+			announcer.SetOnSendAnnouncement(r.onAnnounceCallback)
+		}
+	}
+
+	// Provide resource records to announcer for DNS message serialization
+	if announcer := machine.GetAnnouncer(); announcer != nil {
+		announcer.SetRecords(recordSet)
+	}
+
+	// Run state machine (probing + announcing)
+	if err := machine.Run(r.ctx, serviceName); err != nil {
+		var zero state.State
+		return zero, fmt.Errorf("state machine failed: %w", err)
+	}
+
+	return machine.GetState(), nil
 }
 
 // Unregister unregisters a service and sends goodbye packets per RFC 6762 §10.1.

--- a/responder/query_handler.go
+++ b/responder/query_handler.go
@@ -166,176 +166,187 @@ func (r *Responder) handleQuery(packet []byte, srcAddr net.Addr, interfaceIndex 
 		return nil
 	}
 
-	// DNS-SD meta-query name per RFC 6763 §9
-	const serviceEnumerationName = "_services._dns-sd._udp.local"
-
 	// Process each question
 	for _, question := range msg.Questions {
 		// RFC 6763 §9: Service Type Enumeration
 		// A PTR query for "_services._dns-sd._udp.local" returns all unique service types.
 		if question.QTYPE == uint16(protocol.RecordTypePTR) && question.QNAME == serviceEnumerationName {
-			serviceTypes := r.registry.ListServiceTypes()
-			if len(serviceTypes) == 0 {
-				continue // No services registered, no response needed
-			}
-
-			// Build PTR records: one for each unique service type
-			ptrRecords := make([]*message.ResourceRecord, 0, len(serviceTypes))
-			for _, svcType := range serviceTypes {
-				// RDATA for PTR record is the encoded service type name
-				encodedTarget, encErr := message.EncodeName(svcType)
-				if encErr != nil {
-					continue // Skip types that cannot be encoded
-				}
-				ptrRecords = append(ptrRecords, &message.ResourceRecord{
-					Name:       serviceEnumerationName,
-					Type:       protocol.RecordTypePTR,
-					Class:      protocol.ClassIN,
-					TTL:        protocol.TTLHostname, // 4500s per RFC 6762 §10
-					Data:       encodedTarget,
-					CacheFlush: false, // PTR is a shared record
-				})
-			}
-
-			if len(ptrRecords) == 0 {
-				continue
-			}
-
-			// Build DNS response message
-			responseMsg, buildErr := message.BuildResponse(ptrRecords)
-			if buildErr != nil {
-				continue
-			}
-
-			// Determine destination (unicast vs multicast based on QU bit)
-			quBit := (question.QCLASS & 0x8000) != 0
-			var dest net.Addr
-			if quBit {
-				dest = srcAddr
-			}
-			// nil dest = multicast to 224.0.0.251:5353
-
-			_ = r.transport.Send(r.ctx, responseMsg, dest)
+			r.handleServiceEnumerationQuery(question, srcAddr)
 			continue
 		}
 
-		// Get all registered services
-		services := r.registry.List()
-
-		var matchedService *responder.Service
-		for _, instanceName := range services {
-			service, found := r.registry.Get(instanceName)
-			if !found {
-				continue
-			}
-
-			switch question.QTYPE {
-			case uint16(protocol.RecordTypePTR):
-				// PTR: match by service type (e.g., "_http._tcp.local")
-				if service.ServiceType == question.QNAME {
-					matchedService = service
-				}
-			case uint16(protocol.RecordTypeSRV), uint16(protocol.RecordTypeTXT):
-				// SRV/TXT: match by full instance name (e.g., "My Printer._http._tcp.local")
-				fullName := service.InstanceName + "." + service.ServiceType
-				if fullName == question.QNAME {
-					matchedService = service
-				}
-			case uint16(protocol.RecordTypeA):
-				// A: match by hostname (e.g., "myhost.local")
-				if r.hostname == question.QNAME {
-					matchedService = service
-				}
-			}
-
-			if matchedService != nil {
-				break
-			}
-		}
-
+		matchedService := r.findMatchingService(question)
 		if matchedService == nil {
 			continue
 		}
 
-		// We have a match! Build response with interface-specific addressing
-		//
-		// RFC 6762 §15 "Responding to Address Queries":
-		// "When a Multicast DNS responder sends a Multicast DNS response message
-		// containing its own address records in response to a query received on
-		// a particular interface, it MUST include only addresses that are valid
-		// on that interface, and MUST NOT include addresses configured on other
-		// interfaces."
-		//
-		// T036: Inline comment citing RFC 6762 §15
-		var ipv4 []byte
-		var ipErr error
-
-		// T030: Graceful fallback when interface index unavailable (interfaceIndex=0)
-		// This happens when control messages aren't supported or platform doesn't provide IP_PKTINFO
-		if interfaceIndex == 0 {
-			// Degraded mode: Use default interface IP (legacy behavior)
-			// TODO T032: Add debug logging when F-6 (Logging & Observability) is implemented
-			ipv4, ipErr = getLocalIPv4()
-		} else {
-			// RFC 6762 §15 compliance: Use ONLY the IP from the receiving interface
-			ipv4, ipErr = getIPv4ForInterface(interfaceIndex)
-		}
-
-		if ipErr != nil {
-			// T031: If interface-specific IP lookup fails, skip response for this query
-			// This is correct behavior per RFC 6762 §15: Better to not respond than
-			// to respond with an incorrect (wrong interface) IP address
-			// TODO T032: Add error logging when F-6 is implemented
-			// Common failure causes: interface went down, no IPv4 configured, invalid index
-			continue
-		}
-
-		serviceWithIP := &responder.ServiceWithIP{
-			InstanceName: matchedService.InstanceName,
-			ServiceType:  matchedService.ServiceType,
-			Domain:       "local",
-			Port:         matchedService.Port,
-			IPv4Address:  ipv4,
-			TXTRecords:   matchedService.TXT, // internal.Service uses TXT field
-			Hostname:     r.hostname,
-		}
-
-		// Build response (T076)
-		response, err := r.responseBuilder.BuildResponse(serviceWithIP, msg)
-		if err != nil {
-			continue
-		}
-
-		// Per-source-IP rate limiting (FR-026, RFC 6762 §6.2)
-		if r.rateLimiter != nil && srcAddr != nil {
-			srcIP := srcAddr.String()
-			if udpAddr, ok := srcAddr.(*net.UDPAddr); ok {
-				srcIP = udpAddr.IP.String()
-			}
-			if !r.rateLimiter.Allow(srcIP) {
-				continue // Rate-limited, skip response
-			}
-		}
-
-		// RFC 6762 §5.4: Check QU bit (bit 15 of QCLASS) to determine unicast vs multicast
-		// Task 4: QU bit handling
-		quBit := (question.QCLASS & 0x8000) != 0
-
-		var dest net.Addr
-		if quBit {
-			// RFC 6762 §5.4: QU bit set → send unicast response to querier
-			dest = srcAddr
-		} else {
-			// RFC 6762 §5.4: QU bit clear → send multicast response
-			dest = nil // nil = multicast to 224.0.0.251:5353
-		}
-
-		// Send response
-		responsePacket := buildResponsePacket(response)
-		_ = r.transport.Send(r.ctx, responsePacket, dest)
+		r.respondToQuery(matchedService, msg, question, srcAddr, interfaceIndex)
 	}
 
 	return nil
+}
+
+// serviceEnumerationName is the DNS-SD meta-query name per RFC 6763 §9.
+const serviceEnumerationName = "_services._dns-sd._udp.local"
+
+// handleServiceEnumerationQuery responds to a DNS-SD Service Type Enumeration
+// query (RFC 6763 §9) with a PTR record for each unique registered service type.
+func (r *Responder) handleServiceEnumerationQuery(question message.Question, srcAddr net.Addr) {
+	serviceTypes := r.registry.ListServiceTypes()
+	if len(serviceTypes) == 0 {
+		return // No services registered, no response needed
+	}
+
+	// Build PTR records: one for each unique service type
+	ptrRecords := make([]*message.ResourceRecord, 0, len(serviceTypes))
+	for _, svcType := range serviceTypes {
+		// RDATA for PTR record is the encoded service type name
+		encodedTarget, encErr := message.EncodeName(svcType)
+		if encErr != nil {
+			continue // Skip types that cannot be encoded
+		}
+		ptrRecords = append(ptrRecords, &message.ResourceRecord{
+			Name:       serviceEnumerationName,
+			Type:       protocol.RecordTypePTR,
+			Class:      protocol.ClassIN,
+			TTL:        protocol.TTLHostname, // 4500s per RFC 6762 §10
+			Data:       encodedTarget,
+			CacheFlush: false, // PTR is a shared record
+		})
+	}
+
+	if len(ptrRecords) == 0 {
+		return
+	}
+
+	// Build DNS response message
+	responseMsg, buildErr := message.BuildResponse(ptrRecords)
+	if buildErr != nil {
+		return
+	}
+
+	// Determine destination (unicast vs multicast based on QU bit)
+	quBit := (question.QCLASS & 0x8000) != 0
+	var dest net.Addr
+	if quBit {
+		dest = srcAddr
+	}
+	// nil dest = multicast to 224.0.0.251:5353
+
+	_ = r.transport.Send(r.ctx, responseMsg, dest)
+}
+
+// findMatchingService finds a registered service matching question's QTYPE/QNAME.
+func (r *Responder) findMatchingService(question message.Question) *responder.Service {
+	services := r.registry.List()
+
+	for _, instanceName := range services {
+		service, found := r.registry.Get(instanceName)
+		if !found {
+			continue
+		}
+
+		switch question.QTYPE {
+		case uint16(protocol.RecordTypePTR):
+			// PTR: match by service type (e.g., "_http._tcp.local")
+			if service.ServiceType == question.QNAME {
+				return service
+			}
+		case uint16(protocol.RecordTypeSRV), uint16(protocol.RecordTypeTXT):
+			// SRV/TXT: match by full instance name (e.g., "My Printer._http._tcp.local")
+			fullName := service.InstanceName + "." + service.ServiceType
+			if fullName == question.QNAME {
+				return service
+			}
+		case uint16(protocol.RecordTypeA):
+			// A: match by hostname (e.g., "myhost.local")
+			if r.hostname == question.QNAME {
+				return service
+			}
+		}
+	}
+
+	return nil
+}
+
+// respondToQuery builds and sends a response for a matched service using the
+// query's receiving interface (RFC 6762 §15), applying per-source rate limiting
+// (RFC 6762 §6.2) and unicast/multicast destination selection based on the QU
+// bit (RFC 6762 §5.4).
+//
+// RFC 6762 §15 "Responding to Address Queries":
+// "When a Multicast DNS responder sends a Multicast DNS response message
+// containing its own address records in response to a query received on
+// a particular interface, it MUST include only addresses that are valid
+// on that interface, and MUST NOT include addresses configured on other
+// interfaces."
+func (r *Responder) respondToQuery(matchedService *responder.Service, msg *message.DNSMessage, question message.Question, srcAddr net.Addr, interfaceIndex int) {
+	var ipv4 []byte
+	var ipErr error
+
+	// T030: Graceful fallback when interface index unavailable (interfaceIndex=0)
+	// This happens when control messages aren't supported or platform doesn't provide IP_PKTINFO
+	if interfaceIndex == 0 {
+		// Degraded mode: Use default interface IP (legacy behavior)
+		// TODO T032: Add debug logging when F-6 (Logging & Observability) is implemented
+		ipv4, ipErr = getLocalIPv4()
+	} else {
+		// RFC 6762 §15 compliance: Use ONLY the IP from the receiving interface
+		ipv4, ipErr = getIPv4ForInterface(interfaceIndex)
+	}
+
+	if ipErr != nil {
+		// T031: If interface-specific IP lookup fails, skip response for this query
+		// This is correct behavior per RFC 6762 §15: Better to not respond than
+		// to respond with an incorrect (wrong interface) IP address
+		// TODO T032: Add error logging when F-6 is implemented
+		// Common failure causes: interface went down, no IPv4 configured, invalid index
+		return
+	}
+
+	serviceWithIP := &responder.ServiceWithIP{
+		InstanceName: matchedService.InstanceName,
+		ServiceType:  matchedService.ServiceType,
+		Domain:       "local",
+		Port:         matchedService.Port,
+		IPv4Address:  ipv4,
+		TXTRecords:   matchedService.TXT, // internal.Service uses TXT field
+		Hostname:     r.hostname,
+	}
+
+	// Build response (T076)
+	response, err := r.responseBuilder.BuildResponse(serviceWithIP, msg)
+	if err != nil {
+		return
+	}
+
+	// Per-source-IP rate limiting (FR-026, RFC 6762 §6.2)
+	if r.rateLimiter != nil && srcAddr != nil {
+		srcIP := srcAddr.String()
+		if udpAddr, ok := srcAddr.(*net.UDPAddr); ok {
+			srcIP = udpAddr.IP.String()
+		}
+		if !r.rateLimiter.Allow(srcIP) {
+			return // Rate-limited, skip response
+		}
+	}
+
+	// RFC 6762 §5.4: Check QU bit (bit 15 of QCLASS) to determine unicast vs multicast
+	// Task 4: QU bit handling
+	quBit := (question.QCLASS & 0x8000) != 0
+
+	var dest net.Addr
+	if quBit {
+		// RFC 6762 §5.4: QU bit set → send unicast response to querier
+		dest = srcAddr
+	} else {
+		// RFC 6762 §5.4: QU bit clear → send multicast response
+		dest = nil // nil = multicast to 224.0.0.251:5353
+	}
+
+	// Send response
+	responsePacket := buildResponsePacket(response)
+	_ = r.transport.Send(r.ctx, responsePacket, dest)
 }
 
 // parseMessage is a wrapper around message.ParseMessage for easier imports.

--- a/responder/query_handler.go
+++ b/responder/query_handler.go
@@ -35,7 +35,7 @@ func (r *Responder) runQueryHandler() {
 			// Task 2: Capture source address for subnet validation (RFC 6762 §6.4)
 			packet, srcAddr, interfaceIndex, err := r.transport.Receive(r.ctx)
 			if err != nil {
-				// Context cancelled or transport closed
+				// Context canceled or transport closed
 				select {
 				case <-r.ctx.Done():
 					return

--- a/responder/responder_test.go
+++ b/responder/responder_test.go
@@ -1129,7 +1129,7 @@ func TestHandleQuery_SRVQuery(t *testing.T) {
 			return nil
 		},
 		receiveFunc: func(ctx context.Context) ([]byte, net.Addr, int, error) {
-			// Block until context cancelled
+			// Block until context canceled
 			<-ctx.Done()
 			return nil, nil, 0, ctx.Err()
 		},

--- a/responder/service.go
+++ b/responder/service.go
@@ -228,7 +228,7 @@ func describeInvalidServiceType(serviceType string) error {
 	}
 	for i := 1; i < len(name); i++ {
 		c := name[i]
-		if !((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-') {
+		if (c < 'a' || c > 'z') && (c < '0' || c > '9') && c != '-' {
 			return fmt.Errorf("invalid service type %q: character %q at position %d is not allowed; RFC 6763 §7 permits only lowercase letters, digits, and hyphens in service names (use \"-\" instead of \"_\")", serviceType, string(c), i)
 		}
 	}

--- a/specs/007-interface-specific-addressing/contracts/interface_resolver.go
+++ b/specs/007-interface-specific-addressing/contracts/interface_resolver.go
@@ -129,6 +129,7 @@ func DefaultPolicy() InterfaceResolutionPolicy {
 	}
 }
 
+// IsValidIPv4ForResponse validates IPv4 addresses in responses
 // ValidationRules for IPv4 addresses in responses
 //
 // RFC 6762 §15 Requirements:

--- a/tests/fuzz/responder_fuzz_test.go
+++ b/tests/fuzz/responder_fuzz_test.go
@@ -6,6 +6,7 @@ package fuzz
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/joshuafuller/beacon/responder"
@@ -71,7 +72,7 @@ func FuzzServiceRegistration(f *testing.F) {
 		// Construct service from fuzz inputs
 		// Clamp port to uint16 range (fuzz input is int)
 		var portU16 uint16
-		if port > 0 && port <= 65535 {
+		if port > 0 && port <= math.MaxUint16 {
 			portU16 = uint16(port)
 		}
 		svc := &responder.Service{


### PR DESCRIPTION
Even when matching the defined (old) 2.5.0 version of `golangci-lint` there was no way to get the config in the repo to work. This PR fixes:

- the core syntax issue
- Various style related lints that showed up
- refactors: for limit based lints and adds inline ignores
- refactors: to use constants for clarity when relevant
- refactors: to reduce complexity and solve reasonable lints
- resolves: https://github.com/joshuafuller/beacon/issues/8